### PR TITLE
Rename rosetta-validator to rosetta-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 validator-data
-rosetta-validator
+rosetta-cli
 bootstrap_balances.csv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Rosetta-Validator
+# Contributing to rosetta-cli
 
 ## Code of Conduct
 
@@ -48,6 +48,6 @@ be locked to prevent further discussion.
 
 All support requests must be made via [our support team][3].
 
-[1]: https://github.com/coinbase/rosetta-validator/issues
+[1]: https://github.com/coinbase/rosetta-cli/issues
 [2]: https://medium.com/brigade-engineering/the-secrets-to-great-commit-messages-106fc0a92a25
 [3]: https://support.coinbase.com/customer/en/portal/articles/2288496-how-can-i-contact-coinbase-support-

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-# rosetta-validator
+# rosetta-cli
 
-[![Coinbase](https://circleci.com/gh/coinbase/rosetta-validator/tree/master.svg?style=shield)](https://circleci.com/gh/coinbase/rosetta-validator/tree/master)
-[![Coverage Status](https://coveralls.io/repos/github/coinbase/rosetta-validator/badge.svg)](https://coveralls.io/github/coinbase/rosetta-validator)
-[![Go Report Card](https://goreportcard.com/badge/github.com/coinbase/rosetta-validator)](https://goreportcard.com/report/github.com/coinbase/rosetta-validator)
-[![License](https://img.shields.io/github/license/coinbase/rosetta-validator.svg)](https://github.com/coinbase/rosetta-validator/blob/master/LICENSE.txt)
-
-Once you create a Rosetta server, you'll need to test its
-performance and correctness. This validation tool makes that easy!
+[![Coinbase](https://circleci.com/gh/coinbase/rosetta-cli/tree/master.svg?style=shield)](https://circleci.com/gh/coinbase/rosetta-cli/tree/master)
+[![Coverage Status](https://coveralls.io/repos/github/coinbase/rosetta-cli/badge.svg)](https://coveralls.io/github/coinbase/rosetta-cli)
+[![Go Report Card](https://goreportcard.com/badge/github.com/coinbase/rosetta-cli)](https://goreportcard.com/report/github.com/coinbase/rosetta-cli)
+[![License](https://img.shields.io/github/license/coinbase/rosetta-cli.svg)](https://github.com/coinbase/rosetta-cli/blob/master/LICENSE.txt)
 
 ## What is Rosetta?
 Rosetta is a new project from Coinbase to standardize the process
@@ -22,15 +19,15 @@ and network-specific work.
 
 ## Install
 ```
-go get github.com/coinbase/rosetta-validator
+go get github.com/coinbase/rosetta-cli
 ```
 
 ## Usage
 ```
-A simple CLI to validate a Rosetta server
+CLI for the Rosetta API
 
 Usage:
-  rosetta-validator [command]
+  rosetta-cli [command]
 
 Available Commands:
   check:account  Debug inactive reconciliation errors for a group of accounts
@@ -46,7 +43,7 @@ Flags:
       --halt-on-reconciliation-error   Determines if block processing should halt on a reconciliation
                                        error. It can be beneficial to collect all reconciliation errors or silence
                                        reconciliation errors during development. (default true)
-  -h, --help                           help for rosetta-validator
+  -h, --help                           help for rosetta-cli
       --log-balance-changes            log balance changes
       --log-blocks                     log processed blocks
       --log-reconciliations            log balance reconciliations
@@ -55,7 +52,7 @@ Flags:
       --start int                      block index to start syncing (default -1)
       --transaction-concurrency uint   concurrency to use while fetching transactions (if required) (default 16)
 
-Use "rosetta-validator [command] --help" for more information about a command.
+Use "rosetta-cli [command] --help" for more information about a command.
 ```
 
 ### check:complete
@@ -70,7 +67,7 @@ to discard some number of blocks populate the --start flag with some block
 index less than the last computed block index.
 
 Usage:
-  rosetta-validator check:complete [flags]
+  rosetta-cli check:complete [flags]
 
 Flags:
       --bootstrap-balances string   Absolute path to a file used to bootstrap balances before starting syncing.
@@ -103,7 +100,7 @@ provide a populated --start flag. If you want to run a stateful validation,
 use the check:complete command.
 
 Usage:
-  rosetta-validator check:quick [flags]
+  rosetta-cli check:quick [flags]
 
 Flags:
   -h, --help   help for check:quick
@@ -121,7 +118,7 @@ In the future, this tool will be deprecated as check:complete
 will automatically identify the block where the missing operation occurred.
 
 Usage:
-  rosetta-validator check:account [flags]
+  rosetta-cli check:account [flags]
 
 Flags:
   -h, --help                          help for check:account

--- a/change.patch
+++ b/change.patch
@@ -1,0 +1,366 @@
+diff --git a/.gitignore b/.gitignore
+index 83329a2..a5f8bb1 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1,3 +1,3 @@
+ validator-data
+-rosetta-validator
++rosetta-cli
+ bootstrap_balances.csv
+diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
+index a210817..70312d1 100644
+--- a/CONTRIBUTING.md
++++ b/CONTRIBUTING.md
+@@ -1,4 +1,4 @@
+-# Contributing to Rosetta-Validator
++# Contributing to rosetta-cli
+ 
+ ## Code of Conduct
+ 
+@@ -48,6 +48,6 @@ be locked to prevent further discussion.
+ 
+ All support requests must be made via [our support team][3].
+ 
+-[1]: https://github.com/coinbase/rosetta-validator/issues
++[1]: https://github.com/coinbase/rosetta-cli/issues
+ [2]: https://medium.com/brigade-engineering/the-secrets-to-great-commit-messages-106fc0a92a25
+ [3]: https://support.coinbase.com/customer/en/portal/articles/2288496-how-can-i-contact-coinbase-support-
+diff --git a/README.md b/README.md
+index d0d97e1..046e860 100644
+--- a/README.md
++++ b/README.md
+@@ -1,12 +1,9 @@
+-# rosetta-validator
++# rosetta-cli
+ 
+-[![Coinbase](https://circleci.com/gh/coinbase/rosetta-validator/tree/master.svg?style=shield)](https://circleci.com/gh/coinbase/rosetta-validator/tree/master)
+-[![Coverage Status](https://coveralls.io/repos/github/coinbase/rosetta-validator/badge.svg)](https://coveralls.io/github/coinbase/rosetta-validator)
+-[![Go Report Card](https://goreportcard.com/badge/github.com/coinbase/rosetta-validator)](https://goreportcard.com/report/github.com/coinbase/rosetta-validator)
+-[![License](https://img.shields.io/github/license/coinbase/rosetta-validator.svg)](https://github.com/coinbase/rosetta-validator/blob/master/LICENSE.txt)
+-
+-Once you create a Rosetta server, you'll need to test its
+-performance and correctness. This validation tool makes that easy!
++[![Coinbase](https://circleci.com/gh/coinbase/rosetta-cli/tree/master.svg?style=shield)](https://circleci.com/gh/coinbase/rosetta-cli/tree/master)
++[![Coverage Status](https://coveralls.io/repos/github/coinbase/rosetta-cli/badge.svg)](https://coveralls.io/github/coinbase/rosetta-cli)
++[![Go Report Card](https://goreportcard.com/badge/github.com/coinbase/rosetta-cli)](https://goreportcard.com/report/github.com/coinbase/rosetta-cli)
++[![License](https://img.shields.io/github/license/coinbase/rosetta-cli.svg)](https://github.com/coinbase/rosetta-cli/blob/master/LICENSE.txt)
+ 
+ ## What is Rosetta?
+ Rosetta is a new project from Coinbase to standardize the process
+@@ -22,15 +19,15 @@ and network-specific work.
+ 
+ ## Install
+ ```
+-go get github.com/coinbase/rosetta-validator
++go get github.com/coinbase/rosetta-cli
+ ```
+ 
+ ## Usage
+ ```
+-A simple CLI to validate a Rosetta server
++CLI for the Rosetta API
+ 
+ Usage:
+-  rosetta-validator [command]
++  rosetta-cli [command]
+ 
+ Available Commands:
+   check:account  Debug inactive reconciliation errors for a group of accounts
+@@ -46,7 +43,7 @@ Flags:
+       --halt-on-reconciliation-error   Determines if block processing should halt on a reconciliation
+                                        error. It can be beneficial to collect all reconciliation errors or silence
+                                        reconciliation errors during development. (default true)
+-  -h, --help                           help for rosetta-validator
++  -h, --help                           help for rosetta-cli
+       --log-balance-changes            log balance changes
+       --log-blocks                     log processed blocks
+       --log-reconciliations            log balance reconciliations
+@@ -55,7 +52,7 @@ Flags:
+       --start int                      block index to start syncing (default -1)
+       --transaction-concurrency uint   concurrency to use while fetching transactions (if required) (default 16)
+ 
+-Use "rosetta-validator [command] --help" for more information about a command.
++Use "rosetta-cli [command] --help" for more information about a command.
+ ```
+ 
+ ### check:complete
+@@ -70,7 +67,7 @@ to discard some number of blocks populate the --start flag with some block
+ index less than the last computed block index.
+ 
+ Usage:
+-  rosetta-validator check:complete [flags]
++  rosetta-cli check:complete [flags]
+ 
+ Flags:
+       --bootstrap-balances string   Absolute path to a file used to bootstrap balances before starting syncing.
+@@ -103,7 +100,7 @@ provide a populated --start flag. If you want to run a stateful validation,
+ use the check:complete command.
+ 
+ Usage:
+-  rosetta-validator check:quick [flags]
++  rosetta-cli check:quick [flags]
+ 
+ Flags:
+   -h, --help   help for check:quick
+@@ -121,7 +118,7 @@ In the future, this tool will be deprecated as check:complete
+ will automatically identify the block where the missing operation occurred.
+ 
+ Usage:
+-  rosetta-validator check:account [flags]
++  rosetta-cli check:account [flags]
+ 
+ Flags:
+   -h, --help                          help for check:account
+diff --git a/cmd/check_account.go b/cmd/check_account.go
+index 96db477..a397b16 100644
+--- a/cmd/check_account.go
++++ b/cmd/check_account.go
+@@ -21,9 +21,9 @@ import (
+ 	"log"
+ 	"path"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/logger"
+-	"github.com/coinbase/rosetta-validator/internal/reconciler"
+-	"github.com/coinbase/rosetta-validator/internal/syncer"
++	"github.com/coinbase/rosetta-cli/internal/logger"
++	"github.com/coinbase/rosetta-cli/internal/reconciler"
++	"github.com/coinbase/rosetta-cli/internal/syncer"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/fetcher"
+ 	"github.com/spf13/cobra"
+diff --git a/cmd/check_complete.go b/cmd/check_complete.go
+index f0b04c7..ce1eea5 100644
+--- a/cmd/check_complete.go
++++ b/cmd/check_complete.go
+@@ -18,10 +18,10 @@ import (
+ 	"context"
+ 	"log"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/logger"
+-	"github.com/coinbase/rosetta-validator/internal/reconciler"
+-	"github.com/coinbase/rosetta-validator/internal/storage"
+-	"github.com/coinbase/rosetta-validator/internal/syncer"
++	"github.com/coinbase/rosetta-cli/internal/logger"
++	"github.com/coinbase/rosetta-cli/internal/reconciler"
++	"github.com/coinbase/rosetta-cli/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/syncer"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/fetcher"
+ 
+diff --git a/cmd/check_quick.go b/cmd/check_quick.go
+index a0128b3..cf8b0ce 100644
+--- a/cmd/check_quick.go
++++ b/cmd/check_quick.go
+@@ -18,9 +18,9 @@ import (
+ 	"context"
+ 	"log"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/logger"
+-	"github.com/coinbase/rosetta-validator/internal/reconciler"
+-	"github.com/coinbase/rosetta-validator/internal/syncer"
++	"github.com/coinbase/rosetta-cli/internal/logger"
++	"github.com/coinbase/rosetta-cli/internal/reconciler"
++	"github.com/coinbase/rosetta-cli/internal/syncer"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/fetcher"
+ 	"github.com/spf13/cobra"
+diff --git a/cmd/root.go b/cmd/root.go
+index a21c29b..833bd28 100644
+--- a/cmd/root.go
++++ b/cmd/root.go
+@@ -20,8 +20,8 @@ import (
+ 
+ var (
+ 	rootCmd = &cobra.Command{
+-		Use:   "rosetta-validator",
+-		Short: "A simple CLI to validate a Rosetta server",
++		Use:   "rosetta-cli",
++		Short: "CLI for the Rosetta API",
+ 	}
+ 
+ 	// DataDir is a folder used to store logs
+@@ -74,7 +74,7 @@ var (
+ )
+ 
+ // Execute handles all invocations of the
+-// rosetta-validator cmd.
++// rosetta-cli cmd.
+ func Execute() error {
+ 	return rootCmd.Execute()
+ }
+diff --git a/go.mod b/go.mod
+index d662bec..2ac0aa0 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,4 +1,4 @@
+-module github.com/coinbase/rosetta-validator
++module github.com/coinbase/rosetta-cli
+ 
+ go 1.13
+ 
+diff --git a/go.sum b/go.sum
+index 9f743a0..09f8872 100644
+--- a/go.sum
++++ b/go.sum
+@@ -8,6 +8,8 @@ github.com/coinbase/rosetta-sdk-go v0.1.5 h1:fkYLDs8f7RuwKDJiaZv4qtVRntCOAcSm6Ve
+ github.com/coinbase/rosetta-sdk-go v0.1.5/go.mod h1:lbmGsBpBiSZWP4WQqEW2CuTweGcU/ioQHwZ8CYo6yO8=
+ github.com/coinbase/rosetta-sdk-go v0.1.6 h1:l6vyt+Gad7TWIy2Tf7giXO8jniBcLPhhW6021QFgIq0=
+ github.com/coinbase/rosetta-sdk-go v0.1.6/go.mod h1:lbmGsBpBiSZWP4WQqEW2CuTweGcU/ioQHwZ8CYo6yO8=
++github.com/coinbase/rosetta-validator v0.1.2 h1:d1i/XuZu3tPEnc/HKLzixK0yXbMyg5UEzS2qba7tv5I=
++github.com/coinbase/rosetta-validator v0.1.2/go.mod h1:SgJPFHi1Ikr+tC5MkUhkrnLQKLT0Qzf7g+s1rnZ3kGo=
+ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
+ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+diff --git a/internal/logger/logger.go b/internal/logger/logger.go
+index c1736d5..fedd36b 100644
+--- a/internal/logger/logger.go
++++ b/internal/logger/logger.go
+@@ -21,7 +21,7 @@ import (
+ 	"os"
+ 	"path"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/storage"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/types"
+ )
+diff --git a/internal/reconciler/reconciler.go b/internal/reconciler/reconciler.go
+index f0dcb6a..d8f778f 100644
+--- a/internal/reconciler/reconciler.go
++++ b/internal/reconciler/reconciler.go
+@@ -19,7 +19,7 @@ import (
+ 	"fmt"
+ 	"reflect"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/storage"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/fetcher"
+ 	"github.com/coinbase/rosetta-sdk-go/types"
+diff --git a/internal/reconciler/stateful_reconciler.go b/internal/reconciler/stateful_reconciler.go
+index 46bbda5..d120ac4 100644
+--- a/internal/reconciler/stateful_reconciler.go
++++ b/internal/reconciler/stateful_reconciler.go
+@@ -22,8 +22,8 @@ import (
+ 	"math/rand"
+ 	"time"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/logger"
+-	"github.com/coinbase/rosetta-validator/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/logger"
++	"github.com/coinbase/rosetta-cli/internal/storage"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/fetcher"
+ 	"github.com/coinbase/rosetta-sdk-go/types"
+diff --git a/internal/reconciler/stateful_reconciler_test.go b/internal/reconciler/stateful_reconciler_test.go
+index 946ff35..2dd0ee2 100644
+--- a/internal/reconciler/stateful_reconciler_test.go
++++ b/internal/reconciler/stateful_reconciler_test.go
+@@ -19,8 +19,8 @@ import (
+ 	"fmt"
+ 	"testing"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/logger"
+-	"github.com/coinbase/rosetta-validator/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/logger"
++	"github.com/coinbase/rosetta-cli/internal/storage"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/types"
+ 	"github.com/stretchr/testify/assert"
+diff --git a/internal/reconciler/stateless_reconciler.go b/internal/reconciler/stateless_reconciler.go
+index f5555bb..f4ffa37 100644
+--- a/internal/reconciler/stateless_reconciler.go
++++ b/internal/reconciler/stateless_reconciler.go
+@@ -19,8 +19,8 @@ import (
+ 	"errors"
+ 	"reflect"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/logger"
+-	"github.com/coinbase/rosetta-validator/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/logger"
++	"github.com/coinbase/rosetta-cli/internal/storage"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/fetcher"
+ 	"github.com/coinbase/rosetta-sdk-go/types"
+diff --git a/internal/syncer/base_handler.go b/internal/syncer/base_handler.go
+index 931098b..a04b760 100644
+--- a/internal/syncer/base_handler.go
++++ b/internal/syncer/base_handler.go
+@@ -18,9 +18,9 @@ import (
+ 	"context"
+ 	"log"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/logger"
+-	"github.com/coinbase/rosetta-validator/internal/reconciler"
+-	"github.com/coinbase/rosetta-validator/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/logger"
++	"github.com/coinbase/rosetta-cli/internal/reconciler"
++	"github.com/coinbase/rosetta-cli/internal/storage"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/types"
+ )
+diff --git a/internal/syncer/stateful_syncer.go b/internal/syncer/stateful_syncer.go
+index 114f8c5..6b52f56 100644
+--- a/internal/syncer/stateful_syncer.go
++++ b/internal/syncer/stateful_syncer.go
+@@ -19,7 +19,7 @@ import (
+ 	"errors"
+ 	"fmt"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/storage"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/fetcher"
+ 	"github.com/coinbase/rosetta-sdk-go/types"
+diff --git a/internal/syncer/stateful_syncer_test.go b/internal/syncer/stateful_syncer_test.go
+index acaf071..ec5218b 100644
+--- a/internal/syncer/stateful_syncer_test.go
++++ b/internal/syncer/stateful_syncer_test.go
+@@ -19,7 +19,7 @@ import (
+ 	"fmt"
+ 	"testing"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/storage"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/asserter"
+ 	"github.com/coinbase/rosetta-sdk-go/fetcher"
+diff --git a/internal/syncer/syncer.go b/internal/syncer/syncer.go
+index b3012b3..bf337c8 100644
+--- a/internal/syncer/syncer.go
++++ b/internal/syncer/syncer.go
+@@ -20,7 +20,7 @@ import (
+ 	"log"
+ 	"math/big"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/storage"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/asserter"
+ 	"github.com/coinbase/rosetta-sdk-go/fetcher"
+diff --git a/internal/syncer/syncer_test.go b/internal/syncer/syncer_test.go
+index 0c311de..537653e 100644
+--- a/internal/syncer/syncer_test.go
++++ b/internal/syncer/syncer_test.go
+@@ -18,7 +18,7 @@ import (
+ 	"context"
+ 	"testing"
+ 
+-	"github.com/coinbase/rosetta-validator/internal/storage"
++	"github.com/coinbase/rosetta-cli/internal/storage"
+ 
+ 	"github.com/coinbase/rosetta-sdk-go/asserter"
+ 	"github.com/coinbase/rosetta-sdk-go/types"
+diff --git a/main.go b/main.go
+index 1f8dd4a..a68c3ee 100644
+--- a/main.go
++++ b/main.go
+@@ -17,7 +17,7 @@ package main
+ import (
+ 	"log"
+ 
+-	"github.com/coinbase/rosetta-validator/cmd"
++	"github.com/coinbase/rosetta-cli/cmd"
+ )
+ 
+ func main() {

--- a/cmd/check_account.go
+++ b/cmd/check_account.go
@@ -21,9 +21,9 @@ import (
 	"log"
 	"path"
 
-	"github.com/coinbase/rosetta-validator/internal/logger"
-	"github.com/coinbase/rosetta-validator/internal/reconciler"
-	"github.com/coinbase/rosetta-validator/internal/syncer"
+	"github.com/coinbase/rosetta-cli/internal/logger"
+	"github.com/coinbase/rosetta-cli/internal/reconciler"
+	"github.com/coinbase/rosetta-cli/internal/syncer"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/spf13/cobra"

--- a/cmd/check_complete.go
+++ b/cmd/check_complete.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"log"
 
-	"github.com/coinbase/rosetta-validator/internal/logger"
-	"github.com/coinbase/rosetta-validator/internal/reconciler"
-	"github.com/coinbase/rosetta-validator/internal/storage"
-	"github.com/coinbase/rosetta-validator/internal/syncer"
+	"github.com/coinbase/rosetta-cli/internal/logger"
+	"github.com/coinbase/rosetta-cli/internal/reconciler"
+	"github.com/coinbase/rosetta-cli/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/syncer"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 

--- a/cmd/check_quick.go
+++ b/cmd/check_quick.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"log"
 
-	"github.com/coinbase/rosetta-validator/internal/logger"
-	"github.com/coinbase/rosetta-validator/internal/reconciler"
-	"github.com/coinbase/rosetta-validator/internal/syncer"
+	"github.com/coinbase/rosetta-cli/internal/logger"
+	"github.com/coinbase/rosetta-cli/internal/reconciler"
+	"github.com/coinbase/rosetta-cli/internal/syncer"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/spf13/cobra"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,8 +20,8 @@ import (
 
 var (
 	rootCmd = &cobra.Command{
-		Use:   "rosetta-validator",
-		Short: "A simple CLI to validate a Rosetta server",
+		Use:   "rosetta-cli",
+		Short: "CLI for the Rosetta API",
 	}
 
 	// DataDir is a folder used to store logs
@@ -74,7 +74,7 @@ var (
 )
 
 // Execute handles all invocations of the
-// rosetta-validator cmd.
+// rosetta-cli cmd.
 func Execute() error {
 	return rootCmd.Execute()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/coinbase/rosetta-validator
+module github.com/coinbase/rosetta-cli
 
 go 1.13
 

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/coinbase/rosetta-sdk-go v0.1.5 h1:fkYLDs8f7RuwKDJiaZv4qtVRntCOAcSm6Ve
 github.com/coinbase/rosetta-sdk-go v0.1.5/go.mod h1:lbmGsBpBiSZWP4WQqEW2CuTweGcU/ioQHwZ8CYo6yO8=
 github.com/coinbase/rosetta-sdk-go v0.1.6 h1:l6vyt+Gad7TWIy2Tf7giXO8jniBcLPhhW6021QFgIq0=
 github.com/coinbase/rosetta-sdk-go v0.1.6/go.mod h1:lbmGsBpBiSZWP4WQqEW2CuTweGcU/ioQHwZ8CYo6yO8=
+github.com/coinbase/rosetta-validator v0.1.2 h1:d1i/XuZu3tPEnc/HKLzixK0yXbMyg5UEzS2qba7tv5I=
+github.com/coinbase/rosetta-validator v0.1.2/go.mod h1:SgJPFHi1Ikr+tC5MkUhkrnLQKLT0Qzf7g+s1rnZ3kGo=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/coinbase/rosetta-validator/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 )

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/coinbase/rosetta-validator/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"

--- a/internal/reconciler/stateful_reconciler.go
+++ b/internal/reconciler/stateful_reconciler.go
@@ -22,8 +22,8 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/coinbase/rosetta-validator/internal/logger"
-	"github.com/coinbase/rosetta-validator/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/logger"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"

--- a/internal/reconciler/stateful_reconciler_test.go
+++ b/internal/reconciler/stateful_reconciler_test.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/coinbase/rosetta-validator/internal/logger"
-	"github.com/coinbase/rosetta-validator/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/logger"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/assert"

--- a/internal/reconciler/stateless_reconciler.go
+++ b/internal/reconciler/stateless_reconciler.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/coinbase/rosetta-validator/internal/logger"
-	"github.com/coinbase/rosetta-validator/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/logger"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"

--- a/internal/syncer/base_handler.go
+++ b/internal/syncer/base_handler.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"log"
 
-	"github.com/coinbase/rosetta-validator/internal/logger"
-	"github.com/coinbase/rosetta-validator/internal/reconciler"
-	"github.com/coinbase/rosetta-validator/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/logger"
+	"github.com/coinbase/rosetta-cli/internal/reconciler"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 )

--- a/internal/syncer/stateful_syncer.go
+++ b/internal/syncer/stateful_syncer.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/coinbase/rosetta-validator/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"

--- a/internal/syncer/stateful_syncer_test.go
+++ b/internal/syncer/stateful_syncer_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/coinbase/rosetta-validator/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"math/big"
 
-	"github.com/coinbase/rosetta-validator/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/coinbase/rosetta-validator/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/types"

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"log"
 
-	"github.com/coinbase/rosetta-validator/cmd"
+	"github.com/coinbase/rosetta-cli/cmd"
 )
 
 func main() {


### PR DESCRIPTION
### Motivation
Multiple asset issuers provided feedback that `rosetta-validator` is a confusing name for a repository because `validator` typically is used to describe a PoS validator.

### Solution
Rename repo to `rosetta-cli` to fix confusing naming issue and indicate that the repo could contain more tools than just validation.

