### PR TITLE
Exempt Accounts from Balance Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Flags:
       --block-concurrency uint         concurrency to use while fetching blocks (default 8)
       --data-dir string                folder used to store logs and any data used to perform validation (default "./validator-data")
       --end int                        block index to stop syncing (default -1)
+      --exempt-accounts string         Absolute path to a file listing all accounts to exempt from balance
+                                       tracking and reconciliation. Look at the examples directory for an example of
+                                       how to structure this file.
       --halt-on-reconciliation-error   Determines if block processing should halt on a reconciliation
                                        error. It can be beneficial to collect all reconciliation errors or silence
                                        reconciliation errors during development. (default true)

--- a/cmd/check_complete.go
+++ b/cmd/check_complete.go
@@ -77,6 +77,11 @@ historical balance lookup should set this to false.`,
 func runCheckCompleteCmd(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithCancel(context.Background())
 
+	exemptAccounts, err := loadAccounts(ExemptFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fetcher := fetcher.New(
 		ServerURL,
 		fetcher.WithBlockConcurrency(BlockConcurrency),
@@ -133,6 +138,7 @@ func runCheckCompleteCmd(cmd *cobra.Command, args []string) {
 	syncHandler := syncer.NewBaseHandler(
 		logger,
 		r,
+		exemptAccounts,
 	)
 
 	statefulSyncer := syncer.NewStateful(

--- a/cmd/check_quick.go
+++ b/cmd/check_quick.go
@@ -56,6 +56,11 @@ use the check:complete command.`,
 func runCheckQuickCmd(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithCancel(context.Background())
 
+	exemptAccounts, err := loadAccounts(ExemptFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fetcher := fetcher.New(
 		ServerURL,
 		fetcher.WithBlockConcurrency(BlockConcurrency),
@@ -93,6 +98,7 @@ func runCheckQuickCmd(cmd *cobra.Command, args []string) {
 	syncHandler := syncer.NewBaseHandler(
 		logger,
 		r,
+		exemptAccounts,
 	)
 
 	statelessSyncer := syncer.NewStateless(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,10 @@ var (
 	// It can be beneficial to collect all reconciliation errors
 	// during development.
 	HaltOnReconciliationError bool
+
+	// ExemptFile is an absolute path to a file listing all accounts
+	// to exempt from balance tracking and reconciliation.
+	ExemptFile string
 )
 
 // Execute handles all invocations of the
@@ -153,6 +157,14 @@ func init() {
 		`Determines if block processing should halt on a reconciliation
 error. It can be beneficial to collect all reconciliation errors or silence
 reconciliation errors during development.`,
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&ExemptFile,
+		"exempt-accounts",
+		"",
+		`Absolute path to a file listing all accounts to exempt from balance
+tracking and reconciliation. Look at the examples directory for an example of
+how to structure this file.`,
 	)
 
 	rootCmd.AddCommand(checkCompleteCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,13 @@
 package cmd
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"path"
+
+	"github.com/coinbase/rosetta-cli/internal/reconciler"
+
 	"github.com/spf13/cobra"
 )
 
@@ -170,4 +177,28 @@ how to structure this file.`,
 	rootCmd.AddCommand(checkCompleteCmd)
 	rootCmd.AddCommand(checkQuickCmd)
 	rootCmd.AddCommand(checkAccountCmd)
+}
+
+func loadAccounts(filePath string) ([]*reconciler.AccountCurrency, error) {
+	if len(filePath) == 0 {
+		return []*reconciler.AccountCurrency{}, nil
+	}
+
+	accountsRaw, err := ioutil.ReadFile(path.Clean(filePath))
+	if err != nil {
+		return nil, err
+	}
+
+	accounts := []*reconciler.AccountCurrency{}
+	if err := json.Unmarshal(accountsRaw, &accounts); err != nil {
+		return nil, err
+	}
+
+	prettyAccounts, err := json.MarshalIndent(accounts, "", " ")
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Found %d accounts at %s: %s\n", len(accounts), filePath, string(prettyAccounts))
+
+	return accounts, nil
 }

--- a/examples/exempt_accounts.json
+++ b/examples/exempt_accounts.json
@@ -1,0 +1,11 @@
+[
+  {
+    "account_identifier": {
+      "address":"0x379fC39D8744ED0C1c8BCfd86771338b9086660D"
+    },
+    "currency": {
+      "symbol": "ETH",
+      "decimals": 18
+    }
+  }
+]

--- a/internal/syncer/stateful_syncer.go
+++ b/internal/syncer/stateful_syncer.go
@@ -126,6 +126,7 @@ func (s *StatefulSyncer) storeBlockBalanceChanges(
 		s.fetcher.Asserter,
 		block,
 		orphan,
+		s.handler,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/syncer/stateless_syncer.go
+++ b/internal/syncer/stateless_syncer.go
@@ -95,6 +95,7 @@ func (s *StatelessSyncer) SyncRange(
 			s.fetcher.Asserter,
 			block,
 			false,
+			s.handler,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Motivation
Some Rosetta server implementations do not support reconciliation for some accounts. However, it is not possible to exempt these accounts from balance tracking.

### Solution
It is now possible to provide a file of exempt accounts using the `--exempt-accounts` flag. Take a look at the examples folder for an example of one of these types of files.
