### PR TITLE
Improve Inactive Account Reconciliation

### DIFF
--- a/cmd/check_account.go
+++ b/cmd/check_account.go
@@ -78,6 +78,7 @@ func runCheckAccountCmd(cmd *cobra.Command, args []string) {
 		ServerURL,
 		fetcher.WithBlockConcurrency(BlockConcurrency),
 		fetcher.WithTransactionConcurrency(TransactionConcurrency),
+		fetcher.WithRetryElapsedTime(ExtendedRetryElapsedTime),
 	)
 
 	primaryNetwork, _, err := fetcher.InitializeAsserter(ctx)

--- a/cmd/check_complete.go
+++ b/cmd/check_complete.go
@@ -86,6 +86,7 @@ func runCheckCompleteCmd(cmd *cobra.Command, args []string) {
 		ServerURL,
 		fetcher.WithBlockConcurrency(BlockConcurrency),
 		fetcher.WithTransactionConcurrency(TransactionConcurrency),
+		fetcher.WithRetryElapsedTime(ExtendedRetryElapsedTime),
 	)
 
 	// TODO: sync and reconcile on subnetworks, if they exist.

--- a/cmd/check_quick.go
+++ b/cmd/check_quick.go
@@ -65,6 +65,7 @@ func runCheckQuickCmd(cmd *cobra.Command, args []string) {
 		ServerURL,
 		fetcher.WithBlockConcurrency(BlockConcurrency),
 		fetcher.WithTransactionConcurrency(TransactionConcurrency),
+		fetcher.WithRetryElapsedTime(ExtendedRetryElapsedTime),
 	)
 
 	primaryNetwork, _, err := fetcher.InitializeAsserter(ctx)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,10 +19,21 @@ import (
 	"io/ioutil"
 	"log"
 	"path"
+	"time"
 
 	"github.com/coinbase/rosetta-cli/internal/reconciler"
 
 	"github.com/spf13/cobra"
+)
+
+const (
+	// ExtendedRetryElapsedTime is used to override the default fetcher
+	// retry elapsed time. In practice, extending the retry elapsed time
+	// has prevented retry exhaustion errors when many goroutines are
+	// used to fetch data from the Rosetta server.
+	//
+	// TODO: make configurable
+	ExtendedRetryElapsedTime = 5 * time.Minute
 )
 
 var (


### PR DESCRIPTION
### Motivation
Inactive account reconciliation is very simple. It doesn't wait a minimum number of blocks between checks and doesn't prevent multiple goroutines from checking the balance of an account at the same time.

### Solution
This PR adds support for the features described in the motivation. It also extends the retry elapsed time from 1 Minute to 5 minutes.

### Future PR
* Unify stateful/stateless reconciler
* Add inactive reconciliation to check:quick