### PR TITLE
Exit with Correct Status

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -448,12 +448,10 @@ func runCheckCmd(cmd *cobra.Command, args []string) {
 	}()
 
 	err = g.Wait()
-	if err != nil {
-		// TODO: return status code that indicates if reconciliation succeeded or
-		// failed (currently returning exit code 0 no matter what). If we use
-		// log.Fatal on error, the database will not close properly.
-		//
-		// Issue: https://github.com/coinbase/rosetta-cli/issues/20
-		log.Println(err)
+	if err == nil || err == context.Canceled {
+		log.Println("check succeeded")
+	} else {
+		log.Printf("check failed: %s\n", err.Error())
+		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
-	github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200518143022-cea5733d9710
+	github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200519145152-620dbd4e42bd
 	github.com/dgraph-io/badger v1.6.1
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/mattn/goveralls v0.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200513162126-2278020ff1c2 h1:ibaPM
 github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200513162126-2278020ff1c2/go.mod h1:XKM7urGHLqGQJi9kM97N+GpMLJuCAGYXy2wOm3KzxEE=
 github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200518143022-cea5733d9710 h1:XlYar0V5oPA764ZL0oOtNWB5+cgzdLw2cyQiAuVu+4Q=
 github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200518143022-cea5733d9710/go.mod h1:XKM7urGHLqGQJi9kM97N+GpMLJuCAGYXy2wOm3KzxEE=
+github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200519145152-620dbd4e42bd h1:qnKzVb26+2aEEkN7fi1yuDrknocch2M0PqHt5GTpqAQ=
+github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200519145152-620dbd4e42bd/go.mod h1:XKM7urGHLqGQJi9kM97N+GpMLJuCAGYXy2wOm3KzxEE=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/internal/processor/reconciler_handler.go
+++ b/internal/processor/reconciler_handler.go
@@ -98,16 +98,3 @@ func (h *ReconcilerHandler) ReconciliationSucceeded(
 		block,
 	)
 }
-
-// NewAccountSeen is called each time the reconciler adds a new
-// AccountCurrency to the inactiveQueue. These AccountCurrency
-// should be persisted to pass to the reconciler on restart.
-func (h *ReconcilerHandler) NewAccountSeen(
-	ctx context.Context,
-	account *types.AccountIdentifier,
-	currency *types.Currency,
-) error {
-	// We don't persist new accounts here because we are already storing
-	// them when we set their balance in the internal/storage package.
-	return nil
-}


### PR DESCRIPTION
### Motivation
Fix #20

### Solution
* Add upstream change to make sure errors are returned correctly (https://github.com/coinbase/rosetta-sdk-go/pull/30).
* Check if error returned by `errgroup` is just `context.Canceled` (error status 0) or something else (error status 1).

### Other Changes
* Remove `NewAccountSeen` as it is no longer part of the `reconciler.Handler` interface.