### PR TITLE
Automatically Find Blocks With Missing Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,12 @@ only at the current block). If your node does not support this functionality
 set --lookup-balance-by-block to false. This will make reconciliation much
 less efficient but it will still work.
 
-To debug an INACTIVE account reconciliation error, set the
+If check fails due to an INACTIVE reconciliation error (balance changed without
+any corresponding operation), the cli will automatically try to find the block
+missing an operation. If --lookup-balance-by-block is not enabled, this automatic
+debugging tool does not work.
+
+To debug an INACTIVE account reconciliation error without --lookup-balance-by-block, set the
 --interesting-accounts flag to the absolute path of a JSON file containing
 accounts that will be actively checked for balance changes at each block. This
 will return an error at the block where a balance change occurred with no
@@ -123,6 +128,11 @@ Flags:
 Global Flags:
       --server-url string   base URL for a Rosetta server (default "http://localhost:8080")
 ```
+
+#### Status Codes
+If there are no issues found while running `check`, it will exit with a `0` status code.
+If there are any issues, it will exit with a `1` status code. It can be useful
+to run this command as an integration test for any changes to your implementation.
 
 ### create:configuration
 ```
@@ -216,7 +226,7 @@ internal
 
 ## Correctness Checks
 This tool performs a variety of correctness checks using the Rosetta Server. If
-any correctness check fails, the validator will exit and print out a detailed
+any correctness check fails, the CLI will exit and print out a detailed
 message explaining the error.
 
 ### Response Correctness
@@ -245,11 +255,6 @@ involved in any transactions. The balances of accounts could change
 on the blockchain node without being included in an operation
 returned by the Rosetta Node API. Recall that all balance-changing
 operations should be returned by the Rosetta Node API.
-
-## Future Work
-* Automatically test the correctness of a Rosetta Client SDK by constructing,
-signing, and submitting a transaction. This can be further extended by ensuring
-broadcast transactions eventually land in a block.
 
 ## License
 This project is available open source under the terms of the [Apache 2.0 License](https://opensource.org/licenses/Apache-2.0).

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -365,6 +365,7 @@ func findMissingOps(
 		logger,
 		r,
 		fetcher,
+		accountCurrency,
 	)
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -517,6 +518,7 @@ func runCheckCmd(cmd *cobra.Command, args []string) {
 		logger,
 		r,
 		fetcher,
+		nil,
 	)
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -381,7 +381,6 @@ func runCheckCmd(cmd *cobra.Command, args []string) {
 	)
 
 	reconcilerHandler := processor.NewReconcilerHandler(
-		cancel,
 		logger,
 		HaltOnReconciliationError,
 	)
@@ -425,7 +424,7 @@ func runCheckCmd(cmd *cobra.Command, args []string) {
 		primaryNetwork,
 		fetcher,
 		syncerHandler,
-		cancel,
+		cancel, // needed to exit without error when --end flag provided
 		pastBlocks,
 	)
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -53,7 +53,8 @@ const (
 	// InactiveFailureLookbackWindow is the size of each window to check
 	// for missing ops. If a block with missing ops is not found in this
 	// window, another window is created with the preceding
-	// InactiveFailureLookbackWindow blocks.
+	// InactiveFailureLookbackWindow blocks (this process continues
+	// until the client halts the search or the block is found).
 	InactiveFailureLookbackWindow = 250
 )
 
@@ -382,7 +383,7 @@ func findMissingOps(
 
 		// When using concurrency > 1, we could start looking up balance changes
 		// on multiple blocks at once. This can cause us to return the wrong block
-		// that is missing blocks.
+		// that is missing operations.
 		reconciler.WithActiveConcurrency(1),
 
 		// Do not do any inactive lookups when looking for the block with missing

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -79,7 +79,12 @@ only at the current block). If your node does not support this functionality
 set --lookup-balance-by-block to false. This will make reconciliation much
 less efficient but it will still work.
 
-To debug an INACTIVE account reconciliation error, set the
+If check fails due to an INACTIVE reconciliation error (balance changed without
+any corresponding operation), the cli will automatically try to find the block
+missing an operation. If --lookup-balance-by-block is not enabled, this automatic
+debugging tool does not work.
+
+To debug an INACTIVE account reconciliation error without --lookup-balance-by-block, set the
 --interesting-accounts flag to the absolute path of a JSON file containing
 accounts that will be actively checked for balance changes at each block. This
 will return an error at the block where a balance change occurred with no

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
-	github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200519145152-620dbd4e42bd
+	github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200520212551-1f6ff35ffe98
 	github.com/dgraph-io/badger v1.6.1
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.4.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
 	github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200519145152-620dbd4e42bd
 	github.com/dgraph-io/badger v1.6.1
+	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/mattn/goveralls v0.0.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
@@ -85,6 +87,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/goveralls v0.0.5 h1:spfq8AyZ0cCk57Za6/juJ5btQxeE1FaEGMdfcI+XO48=
 github.com/mattn/goveralls v0.0.5/go.mod h1:Xg2LHi51faXLyKXwsndxiW6uxEEQT9+3sjGzzwU4xy0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
@@ -163,6 +167,7 @@ golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191024172528-b4ff53e7a1cb h1:ZxSglHghKPYD8WDeRUzRJrUJtDF0PxsTUSxyqr9/5BI=
 golang.org/x/sys v0.0.0-20191024172528-b4ff53e7a1cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 h1:YTzHMGlqJu67/uEo1lBv0n3wBXhXNeUbB1XfN2vmTm0=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200518143022-cea5733d9710 h1:XlYar
 github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200518143022-cea5733d9710/go.mod h1:XKM7urGHLqGQJi9kM97N+GpMLJuCAGYXy2wOm3KzxEE=
 github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200519145152-620dbd4e42bd h1:qnKzVb26+2aEEkN7fi1yuDrknocch2M0PqHt5GTpqAQ=
 github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200519145152-620dbd4e42bd/go.mod h1:XKM7urGHLqGQJi9kM97N+GpMLJuCAGYXy2wOm3KzxEE=
+github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200520212551-1f6ff35ffe98 h1:FFhhwaOOGqgYsGBPn/u/ZLk87ZmI7gRpp9oz1RLuPvw=
+github.com/coinbase/rosetta-sdk-go v0.2.1-0.20200520212551-1f6ff35ffe98/go.mod h1:XKM7urGHLqGQJi9kM97N+GpMLJuCAGYXy2wOm3KzxEE=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -84,6 +86,7 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	"github.com/coinbase/rosetta-sdk-go/parser"
+	"github.com/coinbase/rosetta-sdk-go/reconciler"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/fatih/color"
 )
@@ -315,7 +316,7 @@ func (l *Logger) ReconcileFailureStream(
 	block *types.BlockIdentifier,
 ) error {
 	// Always print out reconciliation failures
-	if reconciliationType == "INACTIVE" { // TODO: export type
+	if reconciliationType == reconciler.InactiveReconciliation {
 		color.Yellow(
 			"Missing balance-changing operation detected for %s computed balance: %s%s node balance: %s%s",
 			types.AccountString(account),

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/fatih/color"
 )
 
 const (
@@ -314,14 +315,26 @@ func (l *Logger) ReconcileFailureStream(
 	block *types.BlockIdentifier,
 ) error {
 	// Always print out reconciliation failures
-	log.Printf(
-		"%s Reconciliation failed for %s at %d computed: %s node: %s\n",
-		reconciliationType,
-		types.AccountString(account),
-		block.Index,
-		computedBalance,
-		nodeBalance,
-	)
+	if reconciliationType == "INACTIVE" { // TODO: export type
+		color.Yellow(
+			"Missing balance-changing operation detected for %s computed balance: %s%s node balance: %s%s",
+			types.AccountString(account),
+			computedBalance,
+			currency.Symbol,
+			nodeBalance,
+			currency.Symbol,
+		)
+	} else {
+		color.Yellow(
+			"Reconciliation failed for %s at %d computed: %s%s node: %s%s",
+			types.AccountString(account),
+			block.Index,
+			computedBalance,
+			currency.Symbol,
+			nodeBalance,
+			currency.Symbol,
+		)
+	}
 
 	if !l.logReconciliation {
 		return nil

--- a/internal/processor/reconciler_handler.go
+++ b/internal/processor/reconciler_handler.go
@@ -25,19 +25,16 @@ import (
 
 // ReconcilerHandler implements the Reconciler.Handler interface.
 type ReconcilerHandler struct {
-	cancel                    context.CancelFunc
 	logger                    *logger.Logger
 	haltOnReconciliationError bool
 }
 
 // NewReconcilerHandler creates a new ReconcilerHandler.
 func NewReconcilerHandler(
-	cancel context.CancelFunc,
 	logger *logger.Logger,
 	haltOnReconciliationError bool,
 ) *ReconcilerHandler {
 	return &ReconcilerHandler{
-		cancel:                    cancel,
 		logger:                    logger,
 		haltOnReconciliationError: haltOnReconciliationError,
 	}
@@ -69,7 +66,6 @@ func (h *ReconcilerHandler) ReconciliationFailed(
 	}
 
 	if h.haltOnReconciliationError {
-		h.cancel()
 		return errors.New("halting due to reconciliation error")
 	}
 

--- a/internal/processor/reconciler_handler.go
+++ b/internal/processor/reconciler_handler.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coinbase/rosetta-cli/internal/logger"
 
+	"github.com/coinbase/rosetta-sdk-go/reconciler"
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
@@ -27,6 +28,9 @@ import (
 type ReconcilerHandler struct {
 	logger                    *logger.Logger
 	haltOnReconciliationError bool
+
+	InactiveFailure      *reconciler.AccountCurrency
+	InactiveFailureBlock *types.BlockIdentifier
 }
 
 // NewReconcilerHandler creates a new ReconcilerHandler.
@@ -66,13 +70,16 @@ func (h *ReconcilerHandler) ReconciliationFailed(
 	}
 
 	if h.haltOnReconciliationError {
+		if reconciliationType == "INACTIVE" { // TODO: export reconciliation types
+			h.InactiveFailure = &reconciler.AccountCurrency{
+				Account:  account,
+				Currency: currency,
+			}
+			h.InactiveFailureBlock = block
+		}
 		return errors.New("halting due to reconciliation error")
 	}
 
-	// TODO: automatically find block with missing operation
-	// if inactive reconciliation error. Can do this by asserting
-	// the impacted address has a balance change of 0 on all blocks
-	// it is not active.
 	return nil
 }
 

--- a/internal/processor/reconciler_handler.go
+++ b/internal/processor/reconciler_handler.go
@@ -80,13 +80,7 @@ func (h *ReconcilerHandler) ReconciliationFailed(
 			}
 			h.InactiveFailureBlock = block
 		} else {
-			if h.ActiveFailureBlock == nil {
-				h.ActiveFailureBlock = block
-			} else {
-				if block.Index < h.ActiveFailureBlock.Index {
-					h.ActiveFailureBlock = block
-				}
-			}
+			h.ActiveFailureBlock = block
 		}
 		return errors.New("halting due to reconciliation error")
 	}

--- a/internal/processor/reconciler_handler.go
+++ b/internal/processor/reconciler_handler.go
@@ -72,17 +72,19 @@ func (h *ReconcilerHandler) ReconciliationFailed(
 	}
 
 	if h.haltOnReconciliationError {
-		if reconciliationType == "INACTIVE" { // TODO: export reconciliation types
-			// Populate inactive failure information so we try to find missing ops.
+		if reconciliationType == reconciler.InactiveReconciliation {
+			// Populate inactive failure information so we can try to find block with
+			// missing ops.
 			h.InactiveFailure = &reconciler.AccountCurrency{
 				Account:  account,
 				Currency: currency,
 			}
 			h.InactiveFailureBlock = block
 		} else {
+			// If we halt on an active reconciliation error, store in the handler.
 			h.ActiveFailureBlock = block
 		}
-		return errors.New("halting due to reconciliation error")
+		return errors.New("reconciliation error")
 	}
 
 	return nil

--- a/internal/storage/badger_storage.go
+++ b/internal/storage/badger_storage.go
@@ -17,7 +17,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/dgraph-io/badger"
 )
@@ -30,12 +29,12 @@ type BadgerStorage struct {
 
 // NewBadgerStorage creates a new BadgerStorage.
 func NewBadgerStorage(ctx context.Context, dir string) (Database, error) {
-	log.Println("opening database...")
-	db, err := badger.Open(badger.DefaultOptions(dir))
+	options := badger.DefaultOptions(dir)
+	options.Logger = nil
+	db, err := badger.Open(options)
 	if err != nil {
 		return nil, fmt.Errorf("%w could not open badger database", err)
 	}
-	log.Println("database opened")
 
 	return &BadgerStorage{
 		db: db,
@@ -45,11 +44,9 @@ func NewBadgerStorage(ctx context.Context, dir string) (Database, error) {
 // Close closes the database to prevent corruption.
 // The caller should defer this in main.
 func (b *BadgerStorage) Close(ctx context.Context) error {
-	log.Println("closing database...")
 	if err := b.db.Close(); err != nil {
 		return fmt.Errorf("%w unable to close database", err)
 	}
-	log.Println("database closed")
 
 	return nil
 }


### PR DESCRIPTION
### Motivation
Fixes #24.

### Solution
Automatically find a block containing missing operations if an account balance changes without a corresponding operation (only works when `--lookup-balance-by-block` is enabled).