### PR TITLE
Fix update balance genesis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,7 @@ test:
 	${TEST_SCRIPT}
 
 test-cover:	
-	${TEST_SCRIPT} -coverprofile=c.out -covermode=count
-	${GOVERALLS_CMD} -coverprofile=c.out -repotoken ${COVERALLS_TOKEN}
+	if [ "${COVERALLS_TOKEN}" ]; then ${TEST_SCRIPT} -coverprofile=c.out -covermode=count; ${GOVERALLS_CMD} -coverprofile=c.out -repotoken ${COVERALLS_TOKEN}; fi
 
 add-license:
 	${ADDLICENCE_SCRIPT} .

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -490,7 +490,10 @@ func (b *BlockStorage) UpdateBalance(
 	}
 
 	var existingValue string
-	if exists {
+	// Initialize to zero if change.Block == parentBlock == genesis block
+	if parentBlock != nil && change.Block.Hash == parentBlock.Hash {
+		existingValue = "0"
+	} else if exists {
 		parseBal, err := parseBalanceEntry(balance)
 		if err != nil {
 			return err

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -490,7 +490,7 @@ func (b *BlockStorage) UpdateBalance(
 	}
 
 	var existingValue string
-	// Initialize to zero if change.Block == parentBlock == genesis block
+	// Avoid double counting genesis block
 	if parentBlock != nil && change.Block.Hash == parentBlock.Hash {
 		existingValue = "0"
 	} else if exists {

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -491,20 +491,21 @@ func (b *BlockStorage) UpdateBalance(
 
 	var existingValue string
 	switch {
-	// this could happen if balances are bootstrapped and should not be overridden
 	case exists:
+		// This could happen if balances are bootstrapped and should not be
+		// overridden.
 		parseBal, err := parseBalanceEntry(balance)
 		if err != nil {
 			return err
 		}
 
 		existingValue = parseBal.Amount.Value
-	// don't attempt to use the helper if we are going to query the same block
-	// we are processing (causes the duplicate issue).
 	case parentBlock != nil && change.Block.Hash == parentBlock.Hash:
+		// Don't attempt to use the helper if we are going to query the same
+		// block we are processing (causes the duplicate issue).
 		existingValue = "0"
-	// use helper
 	default:
+		// Use helper to fetch existing balance.
 		amount, err := b.helper.AccountBalance(ctx, change.Account, change.Currency, parentBlock)
 		if err != nil {
 			return fmt.Errorf("%w: unable to get previous account balance", err)

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -490,17 +490,18 @@ func (b *BlockStorage) UpdateBalance(
 	}
 
 	var existingValue string
-	// Avoid double counting genesis block
-	if parentBlock != nil && change.Block.Hash == parentBlock.Hash {
+	switch {
+	case parentBlock != nil && change.Block.Hash == parentBlock.Hash:
+		// Avoid double counting genesis block
 		existingValue = "0"
-	} else if exists {
+	case exists:
 		parseBal, err := parseBalanceEntry(balance)
 		if err != nil {
 			return err
 		}
 
 		existingValue = parseBal.Amount.Value
-	} else {
+	default:
 		amount, err := b.helper.AccountBalance(ctx, change.Account, change.Currency, parentBlock)
 		if err != nil {
 			return fmt.Errorf("%w: unable to get previous account balance", err)

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -873,16 +873,16 @@ func (h *MockBlockStorageHelper) AccountBalance(
 	currency *types.Currency,
 	block *types.BlockIdentifier,
 ) (*types.Amount, error) {
-	value := "0"
-	if len(h.AccountBalanceAmount) > 0 {
-		value = h.AccountBalanceAmount
-	}
-
 	if balance, ok := h.AccountBalances[account.Address]; ok {
 		return &types.Amount{
 			Value:    balance,
 			Currency: currency,
 		}, nil
+	}
+
+	value := "0"
+	if len(h.AccountBalanceAmount) > 0 {
+		value = h.AccountBalanceAmount
 	}
 
 	return &types.Amount{


### PR DESCRIPTION
Fixes #29 .

### Motivation
Fixes a bug in genesis account balance which is reported as twice the existing amount.

### Solution
When UpdateBalance is called with `change.Block = parentBlock = genesisBlock`, `existingValue`
is already accounted for in the `AccountBalance`. Avoid double counting this by initializing "existingValue" to zero.

### Open questions
When also using a genesis balance bootstrap, it appears that the bootstrap is overriden and only the balance from the genesis block is returned. Before investigating further, I'd like to confirm what should be the expected behavior here. FWIW considering one or the other higher priority feels like a better solution. The other solution might be adding both the balances, which seems confusing.