### PR TITLE
Skip test-cover if COVERALLS_TOKEN doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,7 @@ test:
 	${TEST_SCRIPT}
 
 test-cover:	
-	${TEST_SCRIPT} -coverprofile=c.out -covermode=count
-	${GOVERALLS_CMD} -coverprofile=c.out -repotoken ${COVERALLS_TOKEN}
+	if [ "${COVERALLS_TOKEN}" ]; then ${TEST_SCRIPT} -coverprofile=c.out -covermode=count; ${GOVERALLS_CMD} -coverprofile=c.out -repotoken ${COVERALLS_TOKEN}; fi
 
 add-license:
 	${ADDLICENCE_SCRIPT} .


### PR DESCRIPTION
### Motivation
On PRs from forked repositories, secrets are not passed (#30). This causes coverage tests to fail.

### Solution
Only run `test-cover` if the coveralls token is set in the environment (inspired by https://github.com/ethereumjs/ethereumjs-vm/pull/402).

### Testing
Ran locally with no coveralls token.