### PR TITLE
Loosen Duplicate Transaction Hash Check

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -312,6 +312,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200406173513-056763e48d71 h1:DOmugCavvUtnUD114C1Wh+UgTgQZ4pMLzXxi1pSt+/Y=
 golang.org/x/crypto v0.0.0-20200406173513-056763e48d71/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -302,7 +302,10 @@ func (b *BlockStorage) StoreBlock(
 
 	// Store all transaction hashes
 	for _, txn := range block.Transactions {
-		transactionHashKey := getTransactionHashKey(block.BlockIdentifier.Hash, txn.TransactionIdentifier.Hash)
+		transactionHashKey := getTransactionHashKey(
+			block.BlockIdentifier.Hash,
+			txn.TransactionIdentifier.Hash,
+		)
 		err = b.storeHash(ctx, transaction, transactionHashKey)
 		if errors.Is(err, ErrDuplicateKey) {
 			return nil, fmt.Errorf(
@@ -367,7 +370,10 @@ func (b *BlockStorage) RemoveBlock(
 
 	// Remove all transaction hashes
 	for _, txn := range block.Transactions {
-		err = transaction.Delete(ctx, getTransactionHashKey(block.BlockIdentifier.Hash, txn.TransactionIdentifier.Hash))
+		err = transaction.Delete(
+			ctx,
+			getTransactionHashKey(block.BlockIdentifier.Hash, txn.TransactionIdentifier.Hash),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -306,9 +306,10 @@ func (b *BlockStorage) StoreBlock(
 		err = b.storeHash(ctx, transaction, transactionHashKey)
 		if errors.Is(err, ErrDuplicateKey) {
 			return nil, fmt.Errorf(
-				"%w %s",
+				"%w transaction %s appears multiple times in block %s",
 				ErrDuplicateTransactionHash,
 				txn.TransactionIdentifier.Hash,
+				block.BlockIdentifier.Hash,
 			)
 		} else if err != nil {
 			return nil, fmt.Errorf("%w: unable to store transaction hash", err)

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -251,8 +251,8 @@ var (
 		},
 		Timestamp: 1,
 		Transactions: []*types.Transaction{
-			simpleTransactionFactory("blahTx3", "addr1", "100", &types.Currency{Symbol: "hello"}),
-			simpleTransactionFactory("blahTx3", "addr1", "100", &types.Currency{Symbol: "hello"}),
+			simpleTransactionFactory("blahTx3", "addr2", "200", &types.Currency{Symbol: "hello"}),
+			simpleTransactionFactory("blahTx3", "addr2", "200", &types.Currency{Symbol: "hello"}),
 		},
 	}
 )

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -347,9 +347,10 @@ func TestBlock(t *testing.T) {
 	t.Run("Set duplicate transaction hash (same block)", func(t *testing.T) {
 		_, err = storage.StoreBlock(ctx, duplicateTxBlock)
 		assert.EqualError(t, err, fmt.Errorf(
-			"%w %s",
+			"%w transaction %s appears multiple times in block %s",
 			ErrDuplicateTransactionHash,
 			"blahTx3",
+			"blah 4",
 		).Error())
 
 		head, err := storage.GetHeadBlockIdentifier(ctx)

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -304,27 +304,31 @@ func TestBlock(t *testing.T) {
 
 	t.Run("Set duplicate transaction hash (from prior block)", func(t *testing.T) {
 		_, err = storage.StoreBlock(ctx, newBlock2)
-		assert.EqualError(t, err, fmt.Errorf(
-			"%w %s",
-			ErrDuplicateTransactionHash,
-			"blahTx",
-		).Error())
+		assert.NoError(t, err)
+
+		block, err := storage.GetBlock(ctx, newBlock2.BlockIdentifier)
+		assert.NoError(t, err)
+		assert.Equal(t, newBlock2, block)
 
 		head, err := storage.GetHeadBlockIdentifier(ctx)
 		assert.NoError(t, err)
-		assert.Equal(t, newBlock.BlockIdentifier, head)
+		assert.Equal(t, newBlock2.BlockIdentifier, head)
 	})
 
 	t.Run("Remove block and re-set block of same hash", func(t *testing.T) {
-		_, err := storage.RemoveBlock(ctx, newBlock.BlockIdentifier)
+		_, err := storage.RemoveBlock(ctx, newBlock2.BlockIdentifier)
 		assert.NoError(t, err)
 
 		head, err := storage.GetHeadBlockIdentifier(ctx)
 		assert.NoError(t, err)
-		assert.Equal(t, newBlock.ParentBlockIdentifier, head)
+		assert.Equal(t, newBlock2.ParentBlockIdentifier, head)
 
-		_, err = storage.StoreBlock(ctx, newBlock)
+		_, err = storage.StoreBlock(ctx, newBlock2)
 		assert.NoError(t, err)
+
+		head, err = storage.GetHeadBlockIdentifier(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, newBlock2.BlockIdentifier, head)
 	})
 
 	t.Run("Add block with complex metadata", func(t *testing.T) {


### PR DESCRIPTION
Fixes #53 

### Summary
Loosen the restriction that transaction hashes need to be globally unique and instead enforce that transaction hashes only need to be unique to a block hash.

As mentioned in #53, many consumers of the Rosetta APIs assume global uniqueness of `network_identifier:block_hash:transaction_hash` and allowing this duplicate hash restriction to be bypassed (even optionally) may cause an implementation to pass `check` when most consumers won't be able to support it.