### PR TITLE
Print Periodic Stats

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -369,7 +369,7 @@ func findMissingOps(
 		nil,
 	)
 
-	blockStorage := storage.NewBlockStorage(ctx, localStore, blockStorageHelper)
+	blockStorage := storage.NewBlockStorage(localStore, blockStorageHelper)
 
 	// Ensure storage is in correct state for starting at index
 	if err = blockStorage.SetNewStartIndex(ctx, startIndex); err != nil {
@@ -544,7 +544,7 @@ func runCheckCmd(cmd *cobra.Command, args []string) {
 		exemptAccounts,
 	)
 
-	blockStorage := storage.NewBlockStorage(ctx, localStore, blockStorageHelper)
+	blockStorage := storage.NewBlockStorage(localStore, blockStorageHelper)
 
 	// Bootstrap balances if provided
 	if len(BootstrapBalances) > 0 {

--- a/internal/processor/reconciler_handler.go
+++ b/internal/processor/reconciler_handler.go
@@ -17,8 +17,10 @@ package processor
 import (
 	"context"
 	"errors"
+	"math/big"
 
 	"github.com/coinbase/rosetta-cli/internal/logger"
+	"github.com/coinbase/rosetta-cli/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/reconciler"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -99,6 +101,13 @@ func (h *ReconcilerHandler) ReconciliationSucceeded(
 	balance string,
 	block *types.BlockIdentifier,
 ) error {
+	// Update counters
+	if reconciliationType == reconciler.InactiveReconciliation {
+		h.logger.CounterStorage.Update(ctx, storage.InactiveReconciliationCounter, big.NewInt(1))
+	} else {
+		h.logger.CounterStorage.Update(ctx, storage.ActiveReconciliationCounter, big.NewInt(1))
+	}
+
 	return h.logger.ReconcileSuccessStream(
 		ctx,
 		reconciliationType,

--- a/internal/processor/reconciler_handler.go
+++ b/internal/processor/reconciler_handler.go
@@ -103,9 +103,9 @@ func (h *ReconcilerHandler) ReconciliationSucceeded(
 ) error {
 	// Update counters
 	if reconciliationType == reconciler.InactiveReconciliation {
-		h.logger.CounterStorage.Update(ctx, storage.InactiveReconciliationCounter, big.NewInt(1))
+		_, _ = h.logger.CounterStorage.Update(ctx, storage.InactiveReconciliationCounter, big.NewInt(1))
 	} else {
-		h.logger.CounterStorage.Update(ctx, storage.ActiveReconciliationCounter, big.NewInt(1))
+		_, _ = h.logger.CounterStorage.Update(ctx, storage.ActiveReconciliationCounter, big.NewInt(1))
 	}
 
 	return h.logger.ReconcileSuccessStream(

--- a/internal/processor/syncer_handler.go
+++ b/internal/processor/syncer_handler.go
@@ -96,13 +96,17 @@ func (h *SyncerHandler) BlockAdded(
 	}
 
 	// Update Counters
-	h.logger.CounterStorage.Update(ctx, storage.BlockCounter, big.NewInt(1))
-	h.logger.CounterStorage.Update(ctx, storage.TransactionCounter, big.NewInt(int64(len(block.Transactions))))
+	_, _ = h.logger.CounterStorage.Update(ctx, storage.BlockCounter, big.NewInt(1))
+	_, _ = h.logger.CounterStorage.Update(
+		ctx,
+		storage.TransactionCounter,
+		big.NewInt(int64(len(block.Transactions))),
+	)
 	opCount := int64(0)
 	for _, txn := range block.Transactions {
 		opCount += int64(len(txn.Operations))
 	}
-	h.logger.CounterStorage.Update(ctx, storage.OperationCounter, big.NewInt(opCount))
+	_, _ = h.logger.CounterStorage.Update(ctx, storage.OperationCounter, big.NewInt(opCount))
 
 	// Mark accounts for reconciliation...this may be
 	// blocking
@@ -130,7 +134,7 @@ func (h *SyncerHandler) BlockRemoved(
 	}
 
 	// Update Counters
-	h.logger.CounterStorage.Update(ctx, storage.OrphanCounter, big.NewInt(1))
+	_, _ = h.logger.CounterStorage.Update(ctx, storage.OrphanCounter, big.NewInt(1))
 
 	// We only attempt to reconciler changes when blocks are added,
 	// not removed

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -160,7 +160,6 @@ type BlockStorage struct {
 
 // NewBlockStorage returns a new BlockStorage.
 func NewBlockStorage(
-	ctx context.Context,
 	db Database,
 	helper Helper,
 ) *BlockStorage {

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -55,7 +55,7 @@ func TestHeadBlockIdentifier(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBlockStorage(ctx, database, &MockBlockStorageHelper{})
+	storage := NewBlockStorage(database, &MockBlockStorageHelper{})
 
 	t.Run("No head block set", func(t *testing.T) {
 		blockIdentifier, err := storage.GetHeadBlockIdentifier(ctx)
@@ -268,7 +268,7 @@ func TestBlock(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBlockStorage(ctx, database, &MockBlockStorageHelper{})
+	storage := NewBlockStorage(database, &MockBlockStorageHelper{})
 
 	t.Run("Set and get block", func(t *testing.T) {
 		_, err := storage.StoreBlock(ctx, newBlock)
@@ -477,7 +477,7 @@ func TestBalance(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBlockStorage(ctx, database, mockHelper)
+	storage := NewBlockStorage(database, mockHelper)
 
 	t.Run("Get unset balance", func(t *testing.T) {
 		amount, block, err := storage.GetBalance(ctx, account, currency, newBlock)
@@ -800,7 +800,7 @@ func TestBootstrapBalances(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBlockStorage(ctx, database, &MockBlockStorageHelper{})
+	storage := NewBlockStorage(database, &MockBlockStorageHelper{})
 	bootstrapBalancesFile := path.Join(newDir, "balances.csv")
 
 	t.Run("File doesn't exist", func(t *testing.T) {
@@ -944,7 +944,7 @@ func TestCreateBlockCache(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBlockStorage(ctx, database, &MockBlockStorageHelper{})
+	storage := NewBlockStorage(database, &MockBlockStorageHelper{})
 
 	t.Run("no blocks processed", func(t *testing.T) {
 		assert.Equal(t, []*types.BlockIdentifier{}, storage.CreateBlockCache(ctx))

--- a/internal/storage/counter_storage.go
+++ b/internal/storage/counter_storage.go
@@ -24,17 +24,14 @@ const (
 	// BlockCounter is the number of added blocks.
 	BlockCounter = "blocks"
 
-	// OrphansCounter is the number of orphaned blocks.
-	OrphansCounter = "orphans"
+	// OrphanCounter is the number of orphaned blocks.
+	OrphanCounter = "orphans"
 
 	// TransactionCounter is the number of processed transactions.
 	TransactionCounter = "transactions"
 
 	// OperationCounter is the number of processed operations.
 	OperationCounter = "operations"
-
-	// AccountsCounter is the number of seen accounts.
-	AccountsCounter = "accounts"
 
 	// ActiveReconciliationCounter is the number of active
 	// reconciliations performed.

--- a/internal/storage/counter_storage.go
+++ b/internal/storage/counter_storage.go
@@ -1,0 +1,120 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+)
+
+const (
+	// BlockCounter is the number of added blocks.
+	BlockCounter = "blocks"
+
+	// OrphansCounter is the number of orphaned blocks.
+	OrphansCounter = "orphans"
+
+	// TransactionCounter is the number of processed transactions.
+	TransactionCounter = "transactions"
+
+	// OperationCounter is the number of processed operations.
+	OperationCounter = "operations"
+
+	// AccountsCounter is the number of seen accounts.
+	AccountsCounter = "accounts"
+
+	// ActiveReconciliationCounter is the number of active
+	// reconciliations performed.
+	ActiveReconciliationCounter = "active_reconciliations"
+
+	// InactiveReconciliationCounter is the number of inactive
+	// reconciliations performed.
+	InactiveReconciliationCounter = "inactive_reconciliations"
+
+	// counterNamespace is preprended to any counter.
+	counterNamespace = "counter"
+)
+
+// CounterStorage implements counter-specific storage methods
+// on top of a Database and DatabaseTransaction interface.
+type CounterStorage struct {
+	db Database
+}
+
+// NewCounterStorage returns a new CounterStorage.
+func NewCounterStorage(
+	db Database,
+) *CounterStorage {
+	return &CounterStorage{
+		db: db,
+	}
+}
+
+func getCounterKey(counter string) []byte {
+	return []byte(fmt.Sprintf("%s/%s", counterNamespace, counter))
+}
+
+func transactionalGet(
+	ctx context.Context,
+	counter string,
+	txn DatabaseTransaction,
+) (*big.Int, error) {
+	exists, val, err := txn.Get(ctx, getCounterKey(counter))
+	if err != nil {
+		return nil, err
+	}
+
+	if !exists {
+		return big.NewInt(0), nil
+	}
+
+	return new(big.Int).SetBytes(val), nil
+}
+
+// Update updates the value of a counter by amount and returns the new value.
+func (c *CounterStorage) Update(
+	ctx context.Context,
+	counter string,
+	amount *big.Int,
+) (*big.Int, error) {
+	transaction := c.db.NewDatabaseTransaction(ctx, true)
+	defer transaction.Discard(ctx)
+
+	val, err := transactionalGet(ctx, counter, transaction)
+	if err != nil {
+		return nil, err
+	}
+
+	newVal := new(big.Int).Add(val, amount)
+
+	if err := transaction.Set(ctx, getCounterKey(counter), newVal.Bytes()); err != nil {
+		return nil, err
+	}
+
+	if err := transaction.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	return newVal, nil
+}
+
+// Get returns the current value of a counter.
+func (c *CounterStorage) Get(ctx context.Context, counter string) (*big.Int, error) {
+	transaction := c.db.NewDatabaseTransaction(ctx, false)
+	defer transaction.Discard(ctx)
+
+	return transactionalGet(ctx, counter, transaction)
+}

--- a/internal/storage/counter_storage_test.go
+++ b/internal/storage/counter_storage_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/coinbase/rosetta-cli/internal/utils"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCounterStorage(t *testing.T) {
+	ctx := context.Background()
+
+	newDir, err := utils.CreateTempDir()
+	assert.NoError(t, err)
+	defer utils.RemoveTempDir(newDir)
+
+	database, err := NewBadgerStorage(ctx, newDir)
+	assert.NoError(t, err)
+	defer database.Close(ctx)
+
+	c := NewCounterStorage(database)
+
+	t.Run("get unset counter", func(t *testing.T) {
+		v, err := c.Get(ctx, "blah")
+		assert.NoError(t, err)
+		assert.Equal(t, v, big.NewInt(0))
+	})
+
+	t.Run("increase counter", func(t *testing.T) {
+		v, err := c.Update(ctx, "blah", big.NewInt(100))
+		assert.NoError(t, err)
+		assert.Equal(t, v, big.NewInt(100))
+
+		v, err = c.Get(ctx, "blah")
+		assert.NoError(t, err)
+		assert.Equal(t, v, big.NewInt(100))
+	})
+
+	t.Run("decrement counter", func(t *testing.T) {
+		v, err := c.Update(ctx, "blah", big.NewInt(-50))
+		assert.NoError(t, err)
+		assert.Equal(t, v, big.NewInt(50))
+
+		v, err = c.Get(ctx, "blah")
+		assert.NoError(t, err)
+		assert.Equal(t, v, big.NewInt(50))
+	})
+
+	t.Run("get unset counter after update", func(t *testing.T) {
+		v, err := c.Get(ctx, "blah2")
+		assert.NoError(t, err)
+		assert.Equal(t, v, big.NewInt(0))
+	})
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/fatih/color"
 )
 
 // CreateTempDir creates a directory in
@@ -30,6 +31,7 @@ func CreateTempDir() (string, error) {
 		return "", err
 	}
 
+	color.Cyan("Using temporary directory %s", storageDir)
 	return storageDir, nil
 }
 


### PR DESCRIPTION
Fixes #27.
Fixed #35.

### Changes
We now print out summary messages every 10 seconds instead of streaming a long list of logs.

Before:
![image](https://user-images.githubusercontent.com/13023275/82514172-e340cc00-9ac9-11ea-8a95-0e28e6477d98.png)

After:
![image](https://user-images.githubusercontent.com/13023275/87610600-a43e8980-c6ba-11ea-9d42-e8a91bcb1043.png)

Additionally, we also print out a warning if a `check succeeded` but no reconciliations were performed.
![image](https://user-images.githubusercontent.com/13023275/87610608-ac96c480-c6ba-11ea-8300-0f723733cc3b.png)
