### PR TITLE
Network Status Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ Usage:
   rosetta-cli [command]
 
 Available Commands:
-  check                Check the correctness of a Rosetta Node API Server
+  check                Check the correctness of a Rosetta Data API Server
   create:configuration Generate a static configuration file for the Asserter
   help                 Help about any command
   version              Print rosetta-cli version
   view:account         View an account balance
   view:block           View a block
+  view:network         View network status
 
 Flags:
   -h, --help                help for rosetta-cli
@@ -169,6 +170,25 @@ Global Flags:
       --server-url string   base URL for a Rosetta server (default "http://localhost:8080")
 ```
 
+### view:network
+```
+While debugging a Data API implementation, it can be very
+useful to view network(s) status. This command fetches the network
+status from all available networks and prints it to the terminal.
+
+If this command errors, it is likely because the /network/* endpoints are
+not formatted correctly.
+
+Usage:
+  rosetta-cli view:network [flags]
+
+Flags:
+  -h, --help   help for view:network
+
+Global Flags:
+      --server-url string   base URL for a Rosetta server (default "http://localhost:8080")
+```
+
 ### view:account
 ```
 While debugging, it is often useful to inspect the state
@@ -192,7 +212,7 @@ Global Flags:
 
 ### view:block
 ```
-While debugging a Node API implementation, it can be very
+While debugging a Data API implementation, it can be very
 useful to inspect block contents. This command allows you to fetch any
 block by index to inspect its contents. It uses the
 fetcher (https://github.com/coinbase/rosetta-sdk-go/tree/master/fetcher) package
@@ -265,8 +285,8 @@ exit.
 The CLI randomly checks the balances of accounts that aren't
 involved in any transactions. The balances of accounts could change
 on the blockchain node without being included in an operation
-returned by the Rosetta Node API. Recall that all balance-changing
-operations should be returned by the Rosetta Node API.
+returned by the Rosetta Data API. Recall that all balance-changing
+operations should be returned by the Rosetta Data API.
 
 ## License
 This project is available open source under the terms of the [Apache 2.0 License](https://opensource.org/licenses/Apache-2.0).

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -628,6 +628,9 @@ func runCheckCmd(cmd *cobra.Command, args []string) {
 			time.Sleep(PeriodicLoggingFrequency)
 		}
 
+		// Print stats one last time before exiting
+		_ = logger.LogCounterStorage(ctx)
+
 		return nil
 	})
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -68,7 +68,7 @@ const (
 var (
 	checkCmd = &cobra.Command{
 		Use:   "check",
-		Short: "Check the correctness of a Rosetta Node API Server",
+		Short: "Check the correctness of a Rosetta Data API Server",
 		Long: `Check all server responses are properly constructed, that
 there are no duplicate blocks and transactions, that blocks can be processed
 from genesis to the current block (re-orgs handled automatically), and that

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ func init() {
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(viewBlockCmd)
 	rootCmd.AddCommand(viewAccountCmd)
+	rootCmd.AddCommand(viewNetworkCmd)
 	rootCmd.AddCommand(createConfigurationCmd)
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/view_block.go
+++ b/cmd/view_block.go
@@ -30,7 +30,7 @@ var (
 	viewBlockCmd = &cobra.Command{
 		Use:   "view:block",
 		Short: "View a block",
-		Long: `While debugging a Node API implementation, it can be very
+		Long: `While debugging a Data API implementation, it can be very
 useful to inspect block contents. This command allows you to fetch any
 block by index to inspect its contents. It uses the
 fetcher (https://github.com/coinbase/rosetta-sdk-go/tree/master/fetcher) package

--- a/cmd/view_network.go
+++ b/cmd/view_network.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"log"
+
+	"github.com/coinbase/rosetta-sdk-go/fetcher"
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	viewNetworkCmd = &cobra.Command{
+		Use:   "view:network",
+		Short: "View network status",
+		Long: `While debugging a Data API implementation, it can be very
+useful to view network(s) status. This command fetches the network
+status from all available networks and prints it to the terminal.
+
+If this command errors, it is likely because the /network/* endpoints are
+not formatted correctly.`,
+		Run: runViewNetworkCmd,
+	}
+)
+
+func runViewNetworkCmd(cmd *cobra.Command, args []string) {
+	ctx := context.Background()
+
+	f := fetcher.New(ServerURL)
+
+	// Attempt to fetch network list
+	networkList, err := f.NetworkListRetry(ctx, nil)
+	if err != nil {
+		log.Fatalf("%s: unable to fetch network list", err.Error())
+	}
+
+	if len(networkList.NetworkIdentifiers) == 0 {
+		log.Fatal("no networks available")
+	}
+
+	for _, network := range networkList.NetworkIdentifiers {
+		color.Cyan(types.PrettyPrintStruct(network))
+		networkOptions, err := f.NetworkOptions(
+			ctx,
+			network,
+			nil,
+		)
+		if err != nil {
+			log.Fatalf("%s: unable to get network options", err.Error())
+		}
+
+		log.Printf("Network options: %s\n", types.PrettyPrintStruct(networkOptions))
+
+		networkStatus, err := f.NetworkStatusRetry(
+			ctx,
+			network,
+			nil,
+		)
+		if err != nil {
+			log.Fatalf("%s: unable to get network status", err.Error())
+		}
+
+		log.Printf("Network status: %s\n", types.PrettyPrintStruct(networkStatus))
+	}
+}

--- a/internal/processor/reconciler_handler.go
+++ b/internal/processor/reconciler_handler.go
@@ -103,7 +103,11 @@ func (h *ReconcilerHandler) ReconciliationSucceeded(
 ) error {
 	// Update counters
 	if reconciliationType == reconciler.InactiveReconciliation {
-		_, _ = h.logger.CounterStorage.Update(ctx, storage.InactiveReconciliationCounter, big.NewInt(1))
+		_, _ = h.logger.CounterStorage.Update(
+			ctx,
+			storage.InactiveReconciliationCounter,
+			big.NewInt(1),
+		)
 	} else {
 		_, _ = h.logger.CounterStorage.Update(ctx, storage.ActiveReconciliationCounter, big.NewInt(1))
 	}

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -83,10 +83,6 @@ var (
 	// hash cannot be stored because it is a duplicate.
 	ErrDuplicateTransactionHash = errors.New("duplicate transaction hash")
 
-	// ErrAlreadyStartedSyncing is returned when trying to bootstrap
-	// balances after syncing has started.
-	ErrAlreadyStartedSyncing = errors.New("cannot bootstrap accounts, already started syncing")
-
 	// ErrDuplicateKey is returned when trying to store a key that
 	// already exists (this is used by storeHash).
 	ErrDuplicateKey = errors.New("duplicate key")
@@ -662,7 +658,8 @@ func (b *BlockStorage) BootstrapBalances(
 
 	_, err = b.GetHeadBlockIdentifier(ctx)
 	if err != ErrHeadBlockNotFound {
-		return ErrAlreadyStartedSyncing
+		log.Println("Skipping balance bootstrapping because already started syncing")
+		return nil
 	}
 
 	// Update balances in database

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -929,7 +929,7 @@ func TestBootstrapBalances(t *testing.T) {
 
 		// Use the created CSV file from the last test
 		err = storage.BootstrapBalances(ctx, bootstrapBalancesFile, genesisBlockIdentifier)
-		assert.EqualError(t, err, ErrAlreadyStartedSyncing.Error())
+		assert.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
Fixes #50 
Fixes #41 

### Changes
* Add `view:network` command (#41)
* Ignore bootstrap accounts flag if already started syncing (#50)
* Print out stats one last time before exit
* Replace references of `Node API` with `Data API`