### PR TITLE
Key Storage Backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
 	github.com/coinbase/rosetta-sdk-go v0.3.3-0.20200720162936-f929bfc4a262
 	github.com/dgraph-io/badger v1.6.1
+	github.com/ethereum/go-ethereum v1.9.15
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,7 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
+github.com/coinbase/rosetta-sdk-go v0.3.2 h1:2Fep2gIHBGDUNZVaRgSYp6KYfGeFbHp97OlJzw2YRsU=
 github.com/coinbase/rosetta-sdk-go v0.3.3-0.20200720162936-f929bfc4a262 h1:mMAn4TAc2uoY8UkWVQuo5PqR8PnZ9WRG+nw50RnHI8U=
 github.com/coinbase/rosetta-sdk-go v0.3.3-0.20200720162936-f929bfc4a262/go.mod h1:xTq9qdqHVg6uA87pMUJLE+PqyXFM4PyqOY79J8MCNGA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -87,6 +88,7 @@ github.com/dop251/goja v0.0.0-20200219165308-d1232e640a87/go.mod h1:Mw6PkjjMXWbT
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/ethereum/go-ethereum v1.9.15 h1:wrWl+QrtutRUJ9LZXdUqBoGoo2b1tOCYRDrAOQhCY3A=
 github.com/ethereum/go-ethereum v1.9.15/go.mod h1:slT8bPPRhXsyNTwHQxrOnjuTZ1sDXRajW11EkJ84QJ0=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=

--- a/internal/storage/key_storage.go
+++ b/internal/storage/key_storage.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package storage
 
 import (
@@ -140,7 +154,10 @@ func (k *KeyStorage) GetAllAddresses(ctx context.Context) ([]string, error) {
 }
 
 // Sign attempts to sign a slice of *types.SigningPayload with the keys in KeyStorage.
-func (k *KeyStorage) Sign(ctx context.Context, payloads []*types.SigningPayload) ([]*types.Signature, error) {
+func (k *KeyStorage) Sign(
+	ctx context.Context,
+	payloads []*types.SigningPayload,
+) ([]*types.Signature, error) {
 	signatures := make([]*types.Signature, len(payloads))
 	for i, payload := range payloads {
 		keyPair, err := k.Get(ctx, payload.Address)

--- a/internal/storage/key_storage.go
+++ b/internal/storage/key_storage.go
@@ -1,0 +1,169 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/coinbase/rosetta-sdk-go/keys"
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+// WARNING: KEY STORAGE USING THIS PACKAGE IS NOT SECURE!!!! ONLY USE
+// FOR TESTING!!!!
+
+const (
+	keyNamespace = "key"
+)
+
+func getAddressKey(address string) []byte {
+	return []byte(
+		fmt.Sprintf("%s/%s", keyNamespace, address),
+	)
+}
+
+// KeyStorage implements key storage methods
+// on top of a Database and DatabaseTransaction interface.
+type KeyStorage struct {
+	db Database
+}
+
+// NewKeyStorage returns a new KeyStorage.
+func NewKeyStorage(
+	db Database,
+) *KeyStorage {
+	return &KeyStorage{
+		db: db,
+	}
+}
+
+type key struct {
+	Address string        `json:"address"`
+	KeyPair *keys.KeyPair `json:"keypair"`
+}
+
+func parseKey(buf []byte) (*key, error) {
+	var k key
+	err := getDecoder(bytes.NewReader(buf)).Decode(&k)
+	if err != nil {
+		return nil, err
+	}
+
+	return &k, nil
+}
+
+func serializeKey(k *key) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	err := getEncoder(buf).Encode(k)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// Store saves a keys.KeyPair for a given address. If the address already
+// exists, an error is returned.
+func (k *KeyStorage) Store(ctx context.Context, address string, keyPair *keys.KeyPair) error {
+	transaction := k.db.NewDatabaseTransaction(ctx, true)
+	defer transaction.Discard(ctx)
+
+	exists, _, err := transaction.Get(ctx, getAddressKey(address))
+	if err != nil {
+		return fmt.Errorf("%w: unable to check if address %s exists", err, address)
+	}
+
+	if exists {
+		return fmt.Errorf("address %s already exists", address)
+	}
+
+	val, err := serializeKey(&key{
+		Address: address,
+		KeyPair: keyPair,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: unable to serialize key", err)
+	}
+
+	err = transaction.Set(ctx, getAddressKey(address), val)
+	if err != nil {
+		return fmt.Errorf("%w: unable to store key", err)
+	}
+
+	if err := transaction.Commit(ctx); err != nil {
+		return fmt.Errorf("%w: unable to commit new key to db", err)
+	}
+
+	return nil
+}
+
+// Get returns a *keys.KeyPair for an address, if it exists.
+func (k *KeyStorage) Get(ctx context.Context, address string) (*keys.KeyPair, error) {
+	transaction := k.db.NewDatabaseTransaction(ctx, false)
+	defer transaction.Discard(ctx)
+
+	exists, rawKey, err := transaction.Get(ctx, getAddressKey(address))
+	if err != nil {
+		return nil, fmt.Errorf("%w: unable to get address %s", err, address)
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("address not found %s", address)
+	}
+
+	key, err := parseKey(rawKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: unable to parse saved key", err)
+	}
+
+	return key.KeyPair, nil
+}
+
+// GetAllAddresses returns all addresses in key storage.
+func (k *KeyStorage) GetAllAddresses(ctx context.Context) ([]string, error) {
+	rawKeys, err := k.db.Scan(ctx, []byte(keyNamespace))
+	if err != nil {
+		return nil, fmt.Errorf("%w database scan for keys failed", err)
+	}
+
+	addresses := make([]string, len(rawKeys))
+	for i, rawKey := range rawKeys {
+		kp, err := parseKey(rawKey)
+		if err != nil {
+			return nil, fmt.Errorf("%w: unable to parse key pair", err)
+		}
+
+		addresses[i] = kp.Address
+	}
+
+	return addresses, nil
+}
+
+// Sign attempts to sign a slice of *types.SigningPayload with the keys in KeyStorage.
+func (k *KeyStorage) Sign(ctx context.Context, payloads []*types.SigningPayload) ([]*types.Signature, error) {
+	signatures := make([]*types.Signature, len(payloads))
+	for i, payload := range payloads {
+		keyPair, err := k.Get(ctx, payload.Address)
+		if err != nil {
+			return nil, fmt.Errorf("%w: could not get key for %s", err, payload.Address)
+		}
+
+		signer, err := keyPair.Signer()
+		if err != nil {
+			return nil, fmt.Errorf("%w: unable to create signer", err)
+		}
+
+		if len(payload.SignatureType) == 0 {
+			return nil, fmt.Errorf("cannot determine signature type for payload %d", i)
+		}
+
+		signature, err := signer.Sign(payload, payload.SignatureType)
+		if err != nil {
+			return nil, fmt.Errorf("%w: unable to to sign payload %d", err, i)
+		}
+
+		signatures[i] = signature
+	}
+
+	return signatures, nil
+}

--- a/internal/storage/key_storage_test.go
+++ b/internal/storage/key_storage_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package storage
 
 import (

--- a/internal/storage/key_storage_test.go
+++ b/internal/storage/key_storage_test.go
@@ -1,0 +1,131 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coinbase/rosetta-cli/internal/utils"
+
+	"github.com/coinbase/rosetta-sdk-go/keys"
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func hash(message string) []byte {
+	messageHashBytes := common.BytesToHash([]byte(message)).Bytes()
+	return messageHashBytes
+}
+
+func TestKeyStorage(t *testing.T) {
+	ctx := context.Background()
+
+	newDir, err := utils.CreateTempDir()
+	assert.NoError(t, err)
+	defer utils.RemoveTempDir(newDir)
+
+	database, err := NewBadgerStorage(ctx, newDir)
+	assert.NoError(t, err)
+	defer database.Close(ctx)
+
+	k := NewKeyStorage(database)
+
+	kp1, err := keys.GenerateKeypair(types.Edwards25519)
+	assert.NoError(t, err)
+
+	kp2, err := keys.GenerateKeypair(types.Secp256k1)
+	assert.NoError(t, err)
+
+	t.Run("get non-existent key", func(t *testing.T) {
+		v, err := k.Get(ctx, "blah")
+		assert.Error(t, err)
+		assert.Nil(t, v)
+
+		addrs, err := k.GetAllAddresses(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, addrs, 0)
+	})
+
+	t.Run("store and get key", func(t *testing.T) {
+		err = k.Store(ctx, "addr1", kp1)
+		assert.NoError(t, err)
+
+		v, err := k.Get(ctx, "addr1")
+		assert.NoError(t, err)
+		assert.Equal(t, kp1, v)
+
+		addrs, err := k.GetAllAddresses(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"addr1"}, addrs)
+	})
+
+	t.Run("attempt overwrite", func(t *testing.T) {
+		err = k.Store(ctx, "addr1", kp2)
+		assert.Error(t, err)
+
+		v, err := k.Get(ctx, "addr1")
+		assert.NoError(t, err)
+		assert.Equal(t, kp1, v)
+	})
+
+	t.Run("store and get another key", func(t *testing.T) {
+		err = k.Store(ctx, "addr2", kp2)
+		assert.NoError(t, err)
+
+		v, err := k.Get(ctx, "addr2")
+		assert.NoError(t, err)
+		assert.Equal(t, kp2, v)
+
+		addrs, err := k.GetAllAddresses(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"addr1", "addr2"}, addrs)
+	})
+
+	t.Run("sign payloads", func(t *testing.T) {
+		payloads := []*types.SigningPayload{
+			{
+				Address:       "addr1",
+				Bytes:         hash("msg1"),
+				SignatureType: types.Ed25519,
+			},
+			{
+				Address:       "addr2",
+				Bytes:         hash("msg2"),
+				SignatureType: types.Ecdsa,
+			},
+		}
+
+		sigs, err := k.Sign(ctx, payloads)
+		assert.NoError(t, err)
+		assert.Len(t, sigs, 2)
+		assert.NoError(t, (&keys.SignerEdwards25519{}).Verify(sigs[0]))
+		assert.NoError(t, (&keys.SignerSecp256k1{}).Verify(sigs[1]))
+	})
+
+	t.Run("missing address in sign", func(t *testing.T) {
+		payloads := []*types.SigningPayload{
+			{
+				Address:       "addr3",
+				Bytes:         hash("msg3"),
+				SignatureType: types.Ed25519,
+			},
+		}
+
+		sigs, err := k.Sign(ctx, payloads)
+		assert.Error(t, err)
+		assert.Nil(t, sigs)
+	})
+
+	t.Run("missing signature type in sign", func(t *testing.T) {
+		payloads := []*types.SigningPayload{
+			{
+				Address: "addr1",
+				Bytes:   hash("msg1"),
+			},
+		}
+
+		sigs, err := k.Sign(ctx, payloads)
+		assert.Error(t, err)
+		assert.Nil(t, sigs)
+	})
+}


### PR DESCRIPTION
Related Issue: https://github.com/coinbase/rosetta-cli/issues/68

### Changes
Add `KeyStorage` backend for storing generated `keys.KeyPairs`.