### PR TITLE
Add Configuration File Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ADDLICENSE_CMD=go run github.com/google/addlicense
 ADDLICENCE_SCRIPT=${ADDLICENSE_CMD} -c "Coinbase, Inc." -l "apache" -v
 GOLINES_CMD=go run github.com/segmentio/golines
 GOVERALLS_CMD=go run github.com/mattn/goveralls
-TEST_SCRIPT=go test -v ./internal/...
+TEST_SCRIPT=go test -v ./internal/... ./configuration/...
 
 deps:
 	go get ./...
@@ -39,7 +39,7 @@ check-license:
 	${ADDLICENCE_SCRIPT} -check .
 
 shorten-lines:
-	${GOLINES_CMD} -w --shorten-comments internal cmd
+	${GOLINES_CMD} -w --shorten-comments internal cmd configuration
 
 salus:
 	docker run --rm -t -v ${PWD}:/home/repo coinbase/salus

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -16,15 +16,12 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"os"
 	"os/signal"
-	"path"
 	"syscall"
 	"time"
 
@@ -303,14 +300,9 @@ func loadAccounts(filePath string) ([]*reconciler.AccountCurrency, error) {
 		return []*reconciler.AccountCurrency{}, nil
 	}
 
-	accountsRaw, err := ioutil.ReadFile(path.Clean(filePath))
-	if err != nil {
-		return nil, err
-	}
-
 	accounts := []*reconciler.AccountCurrency{}
-	if err := json.Unmarshal(accountsRaw, &accounts); err != nil {
-		return nil, err
+	if err := utils.LoadAndParse(filePath, &accounts); err != nil {
+		return nil, fmt.Errorf("%w: unable to open account file", err)
 	}
 
 	log.Printf(

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -48,13 +48,6 @@ const (
 	// TODO: make configurable
 	ExtendedRetryElapsedTime = 5 * time.Minute
 
-	// InactiveFailureLookbackWindow is the size of each window to check
-	// for missing ops. If a block with missing ops is not found in this
-	// window, another window is created with the preceding
-	// InactiveFailureLookbackWindow blocks (this process continues
-	// until the client halts the search or the block is found).
-	InactiveFailureLookbackWindow = 250
-
 	// PeriodicLoggingFrequency is the frequency that stats are printed
 	// to the terminal.
 	//
@@ -103,77 +96,11 @@ of what one of these files looks like.`,
 		Run: runCheckCmd,
 	}
 
-	// BootstrapBalances is a path to a file used to bootstrap
-	// balances before starting syncing. Populating this value
-	// after beginning syncing will return an error.
-	BootstrapBalances string
-
-	// LookupBalanceByBlock determines if balances are looked up
-	// at the block where a balance change occurred instead of at the current
-	// block. Blockchains that do not support historical balance lookup
-	// should set this to false.
-	LookupBalanceByBlock bool
-
-	// DataDir is a folder used to store logs
-	// and any data used to perform validation.
-	DataDir string
-
 	// StartIndex is the block index to start syncing.
 	StartIndex int64
 
 	// EndIndex is the block index to stop syncing.
 	EndIndex int64
-
-	// BlockConcurrency is the concurrency to use
-	// while fetching blocks.
-	BlockConcurrency uint64
-
-	// TransactionConcurrency is the concurrency to use
-	// while fetching transactions (if required).
-	TransactionConcurrency uint64
-
-	// ActiveReconciliationConcurrency is the concurrency to use
-	// while fetching accounts during active reconciliation.
-	ActiveReconciliationConcurrency uint64
-
-	// InactiveReconciliationConcurrency is the concurrency to use
-	// while fetching accounts during inactive reconciliation.
-	InactiveReconciliationConcurrency uint64
-
-	// InactiveReconciliationFrequency is the number of blocks
-	// to wait between inactive reconiliations on each account.
-	InactiveReconciliationFrequency uint64
-
-	// LogBlocks determines if blocks are
-	// logged.
-	LogBlocks bool
-
-	// LogTransactions determines if transactions are
-	// logged.
-	LogTransactions bool
-
-	// LogBalanceChanges determines if balance changes are
-	// logged.
-	LogBalanceChanges bool
-
-	// LogReconciliations determines if reconciliations are
-	// logged.
-	LogReconciliations bool
-
-	// HaltOnReconciliationError determines if processing
-	// should stop when encountering a reconciliation error.
-	// It can be beneficial to collect all reconciliation errors
-	// during development.
-	HaltOnReconciliationError bool
-
-	// ExemptFile is an absolute path to a file listing all accounts
-	// to exempt from balance tracking and reconciliation.
-	ExemptFile string
-
-	// InterestingFile is an absolute path to a file listing all accounts
-	// to actively reconcile on each block (if there are no operations
-	// present for the account, the reconciler asserts a balance change of 0).
-	InterestingFile string
 
 	// signalReceived is set to true when a signal causes us to exit. This makes
 	// determining the error message to show on exit much more easy.

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -181,12 +181,6 @@ of what one of these files looks like.`,
 )
 
 func init() {
-	checkCmd.Flags().StringVar(
-		&DataDir,
-		"data-dir",
-		"",
-		"folder used to store logs and any data used to perform validation",
-	)
 	checkCmd.Flags().Int64Var(
 		&StartIndex,
 		"start",
@@ -198,98 +192,6 @@ func init() {
 		"end",
 		-1,
 		"block index to stop syncing",
-	)
-	checkCmd.Flags().Uint64Var(
-		&BlockConcurrency,
-		"block-concurrency",
-		8,
-		"concurrency to use while fetching blocks",
-	)
-	checkCmd.Flags().Uint64Var(
-		&TransactionConcurrency,
-		"transaction-concurrency",
-		16,
-		"concurrency to use while fetching transactions (if required)",
-	)
-	checkCmd.Flags().Uint64Var(
-		&ActiveReconciliationConcurrency,
-		"active-reconciliation-concurrency",
-		8,
-		"concurrency to use while fetching accounts during active reconciliation",
-	)
-	checkCmd.Flags().Uint64Var(
-		&InactiveReconciliationConcurrency,
-		"inactive-reconciliation-concurrency",
-		4,
-		"concurrency to use while fetching accounts during inactive reconciliation",
-	)
-	checkCmd.Flags().Uint64Var(
-		&InactiveReconciliationFrequency,
-		"inactive-reconciliation-frequency",
-		250,
-		"the number of blocks to wait between inactive reconiliations on each account",
-	)
-	checkCmd.Flags().BoolVar(
-		&LogBlocks,
-		"log-blocks",
-		false,
-		"log processed blocks",
-	)
-	checkCmd.Flags().BoolVar(
-		&LogTransactions,
-		"log-transactions",
-		false,
-		"log processed transactions",
-	)
-	checkCmd.Flags().BoolVar(
-		&LogBalanceChanges,
-		"log-balance-changes",
-		false,
-		"log balance changes",
-	)
-	checkCmd.Flags().BoolVar(
-		&LogReconciliations,
-		"log-reconciliations",
-		false,
-		"log balance reconciliations",
-	)
-	checkCmd.Flags().BoolVar(
-		&HaltOnReconciliationError,
-		"halt-on-reconciliation-error",
-		true,
-		`Determines if block processing should halt on a reconciliation
-error. It can be beneficial to collect all reconciliation errors or silence
-reconciliation errors during development.`,
-	)
-	checkCmd.Flags().StringVar(
-		&ExemptFile,
-		"exempt-accounts",
-		"",
-		`Absolute path to a file listing all accounts to exempt from balance
-tracking and reconciliation. Look at the examples directory for an example of
-how to structure this file.`,
-	)
-	checkCmd.Flags().StringVar(
-		&BootstrapBalances,
-		"bootstrap-balances",
-		"",
-		`Absolute path to a file used to bootstrap balances before starting syncing.
-Populating this value after beginning syncing will return an error.`,
-	)
-	checkCmd.Flags().BoolVar(
-		&LookupBalanceByBlock,
-		"lookup-balance-by-block",
-		true,
-		`When set to true, balances are looked up at the block where a balance
-change occurred instead of at the current block. Blockchains that do not support
-historical balance lookup should set this to false.`,
-	)
-	checkCmd.Flags().StringVar(
-		&InterestingFile,
-		"interesting-accounts",
-		"",
-		`Absolute path to a file listing all accounts to check on each block. Look
-at the examples directory for an example of how to structure this file.`,
 	)
 }
 

--- a/cmd/check_construction.go
+++ b/cmd/check_construction.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/check_construction.go
+++ b/cmd/check_construction.go
@@ -15,5 +15,6 @@ var (
 )
 
 func runCheckConstructionCmd(cmd *cobra.Command, args []string) {
+	// ensureDataDirectoryExists()
 	log.Fatal("not implemented!")
 }

--- a/cmd/check_construction.go
+++ b/cmd/check_construction.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	checkConstructionCmd = &cobra.Command{
+		Use:   "check:construction",
+		Short: "Check the correctness of a Rosetta Construction API Implementation",
+		Run:   runCheckConstructionCmd,
+	}
+)
+
+func runCheckConstructionCmd(cmd *cobra.Command, args []string) {
+	log.Fatal("not implemented!")
+}

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -64,7 +64,7 @@ const (
 
 var (
 	checkDataCmd = &cobra.Command{
-		Use:   "check",
+		Use:   "check:data",
 		Short: "Check the correctness of a Rosetta Data API Implementation",
 		Long: `Check all server responses are properly constructed, that
 there are no duplicate blocks and transactions, that blocks can be processed

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -325,6 +325,7 @@ func findMissingOps(
 }
 
 func runCheckDataCmd(cmd *cobra.Command, args []string) {
+	ensureDataDirectoryExists()
 	ctx, cancel := context.WithCancel(context.Background())
 
 	exemptAccounts, err := loadAccounts(Config.Data.ExemptAccounts)

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -65,7 +65,7 @@ const (
 var (
 	checkDataCmd = &cobra.Command{
 		Use:   "check",
-		Short: "Check the correctness of a Rosetta Data API Server",
+		Short: "Check the correctness of a Rosetta Data API Implementation",
 		Long: `Check all server responses are properly constructed, that
 there are no duplicate blocks and transactions, that blocks can be processed
 from genesis to the current block (re-orgs handled automatically), and that

--- a/cmd/configuration_create.go
+++ b/cmd/configuration_create.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/configuration_create.go
+++ b/cmd/configuration_create.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/coinbase/rosetta-cli/configuration"
+	"github.com/coinbase/rosetta-cli/internal/utils"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	configurationCreateCmd = &cobra.Command{
+		Use:   "configuration:create",
+		Short: "Create a default configuration file at the provided path",
+		Run:   runConfigurationCreateCmd,
+		Args:  cobra.ExactArgs(1),
+	}
+)
+
+func runConfigurationCreateCmd(cmd *cobra.Command, args []string) {
+	if err := utils.SerializeAndWrite(args[0], configuration.DefaultConfiguration()); err != nil {
+		log.Fatalf("%s: unable to save configuration file to %s", err.Error(), args[0])
+	}
+}

--- a/cmd/configuration_validate.go
+++ b/cmd/configuration_validate.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/configuration_validate.go
+++ b/cmd/configuration_validate.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/coinbase/rosetta-cli/configuration"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	configurationValidateCmd = &cobra.Command{
+		Use:   "configuration:validate",
+		Short: "Validate the correctness of a configuration file at the provided path",
+		Run:   runConfigurationValidateCmd,
+		Args:  cobra.ExactArgs(1),
+	}
+)
+
+func runConfigurationValidateCmd(cmd *cobra.Command, args []string) {
+	_, err := configuration.LoadConfiguration(args[0])
+	if err != nil {
+		log.Fatalf("%s: unable to save configuration file to %s", err.Error(), args[0])
+	}
+
+	log.Println("Configuration file validated!")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,7 +95,7 @@ func ensureDataDirectoryExists() {
 	if len(Config.Data.DataDirectory) == 0 {
 		tmpDir, err := utils.CreateTempDir()
 		if err != nil {
-			log.Fatal(fmt.Errorf("%w: unable to create temporary directory", err))
+			log.Fatalf("%s: unable to create temporary directory", err.Error())
 		}
 
 		Config.Data.DataDirectory = tmpDir

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,9 @@ func initConfig() {
 	if err != nil {
 		log.Fatalf("%s: unable to load configuration", err.Error())
 	}
+}
 
+func ensureDataDirectoryExists() {
 	// If data directory is not specified, we use a temporary directory
 	// and delete its contents when execution is complete.
 	if len(Config.Data.DataDirectory) == 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,11 @@ var (
 	}
 
 	configurationFile string
-	Config            *configuration.Configuration
+
+	// Config is the populated *configuration.Configuration from
+	// the configurationFile. If none is provided, this is set
+	// to the default settings.
+	Config *configuration.Configuration
 )
 
 // Execute handles all invocations of the

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,8 +47,8 @@ func init() {
 		&configurationFile,
 		"configuration-file",
 		"",
-		"configuration file that provides connection and test settings",
-		`If you would like to generate a starter configuration file (populated
+		`Configuration file that provides connection and test settings.
+If you would like to generate a starter configuration file (populated
 with the defaults), run rosetta-cli configuration:create.
 
 Any fields not populated in the configuration file will be populated with

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,9 +26,7 @@ var (
 		Short: "CLI for the Rosetta API",
 	}
 
-	// ServerURL is the base URL for a Rosetta
-	// server to validate.
-	ServerURL string
+	ConfigurationFile string
 )
 
 // Execute handles all invocations of the
@@ -39,24 +37,39 @@ func Execute() error {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(
-		&ServerURL,
-		"server-url",
-		"http://localhost:8080",
-		"base URL for a Rosetta server",
-	)
+		&ConfigurationFile,
+		"configuration-file",
+		"",
+		"configuration file that provides connection and test settings",
+		`If you would like to generate a starter configuration file (populated
+with the defaults), run rosetta-cli configuration:create.
 
-	rootCmd.AddCommand(checkCmd)
+Any fields not populated in the configuration file will be populated with
+default values.`,
+	)
+	rootCmd.AddCommand(versionCmd)
+
+	// Configuration Commands
+	rootCmd.AddCommand(configurationCreateCmd)
+	rootCmd.AddCommand(configurationValidateCmd)
+
+	// Check commands
+	rootCmd.AddCommand(checkDataCmd)
+	rootCmd.AddCommand(checkConstructionCmd)
+
+	// View Commands
 	rootCmd.AddCommand(viewBlockCmd)
 	rootCmd.AddCommand(viewAccountCmd)
 	rootCmd.AddCommand(viewNetworkCmd)
-	rootCmd.AddCommand(createConfigurationCmd)
-	rootCmd.AddCommand(versionCmd)
+
+	// Utils
+	rootCmd.AddCommand(utilsAsserterConfigurationCmd)
 }
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.3.1")
+		fmt.Println("v0.3.2")
 	},
 }

--- a/cmd/view_account.go
+++ b/cmd/view_account.go
@@ -58,7 +58,7 @@ func runViewAccountCmd(cmd *cobra.Command, args []string) {
 
 	// Create a new fetcher
 	newFetcher := fetcher.New(
-		ServerURL,
+		Config.Data.OnlineURL,
 	)
 
 	// Initialize the fetcher's asserter

--- a/cmd/view_block.go
+++ b/cmd/view_block.go
@@ -53,7 +53,7 @@ func runViewBlockCmd(cmd *cobra.Command, args []string) {
 
 	// Create a new fetcher
 	newFetcher := fetcher.New(
-		ServerURL,
+		Config.Data.OnlineURL,
 	)
 
 	// Initialize the fetcher's asserter

--- a/cmd/view_network.go
+++ b/cmd/view_network.go
@@ -41,7 +41,7 @@ not formatted correctly.`,
 func runViewNetworkCmd(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 
-	f := fetcher.New(ServerURL)
+	f := fetcher.New(Config.Data.OnlineURL)
 
 	// Attempt to fetch network list
 	networkList, err := f.NetworkListRetry(ctx, nil)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/coinbase/rosetta-cli/internal/scenario"
 	"github.com/coinbase/rosetta-cli/internal/utils"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
@@ -42,6 +43,7 @@ const (
 // ConstructionConfiguration contains all configurations
 // to run check:construction.
 type ConstructionConfiguration struct {
+	// TODO: Write comments about each value
 	Network               *types.NetworkIdentifier `json:"network"`
 	OnlineURL             string                   `json:"online_url"`
 	OfflineURL            string                   `json:"offline_url"`
@@ -54,7 +56,80 @@ type ConstructionConfiguration struct {
 	TransferScenario      []*types.Operation       `json:"transfer_scenario"`
 }
 
+func DefaultConstructionConfiguration() *ConstructionConfiguration {
+	// DEFAULT IS ETH
+	return &ConstructionConfiguration{
+		Network: &types.NetworkIdentifier{
+			Blockchain: "Ethereum",
+			Network:    "Ropsten",
+		},
+		OnlineURL:  "http://localhost:8080",
+		OfflineURL: "http://localhost:8080",
+		Currency: &types.Currency{
+			Symbol:   "ETH",
+			Decimals: 18,
+		},
+		MinimumAccountBalance: "0",
+		MinimumFee:            "21000",
+		MaximumFee:            "10000000",
+		CurveType:             types.Secp256k1,
+		AccountingModel:       AccountModel,
+		TransferScenario: []*types.Operation{
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: 0,
+				},
+				Account: &types.AccountIdentifier{
+					Address: scenario.Sender,
+				},
+				Type: "transfer",
+				Amount: &types.Amount{
+					Value: scenario.SenderValue,
+				},
+			},
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: 1,
+				},
+				RelatedOperations: []*types.OperationIdentifier{
+					{
+						Index: 0,
+					},
+				},
+				Account: &types.AccountIdentifier{
+					Address: scenario.Recipient,
+				},
+				Type: "transfer",
+				Amount: &types.Amount{
+					Value: scenario.RecipientValue,
+				},
+			},
+		},
+	}
+}
+
+func DefaultDataConfiguration() *DataConfiguration {
+	return &DataConfiguration{
+		OnlineURL:                         "http://localhost:8080",
+		BlockConcurrency:                  8,
+		TransactionConcurrency:            16,
+		ActiveReconciliationConcurrency:   16,
+		InactiveReconciliationConcurrency: 4,
+		InactiveReconciliationFrequency:   250,
+		HaltOnReconciliationError:         true,
+		LookupBalanceByBlock:              true, // override with setting returned by node?
+	}
+}
+
+func DefaultConfiguration() *Configuration {
+	return &Configuration{
+		Construction: DefaultConstructionConfiguration(),
+		Data:         DefaultDataConfiguration(),
+	}
+}
+
 // DataConfiguration contains all configurations to run check:data.
+// TODO: Add timeout!!
 type DataConfiguration struct {
 	// OnlineURL is the URL of a Rosetta API implementation in "online mode".
 	// default: http://localhost:8080

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1,0 +1,106 @@
+package configuration
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/coinbase/rosetta-cli/internal/utils"
+
+	"github.com/coinbase/rosetta-sdk-go/asserter"
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+// TestingMode is a type representing possible test types.
+// This determines how strictly to parse the configuration file.
+type TestingMode string
+
+const (
+	// DataMode is testing of the Data API using check:data.
+	DataMode TestingMode = "data"
+
+	// ViewMode is viewing certain objects using the Data API.
+	ViewMode TestingMode = "view"
+
+	// ConstructionMode is testing of the Construction API using check:construction.
+	ConstructionMode TestingMode = "construction"
+)
+
+// AccountingModel is a type representing possible accounting models
+// in the Construction API.
+type AccountingModel string
+
+const (
+	// AccountModel is for account-based blockchains.
+	AccountModel AccountingModel = "account"
+
+	// UtxoModel is for UTXO-based blockchains.
+	UtxoModel AccountingModel = "utxo"
+)
+
+// ConstructionConfiguration contains all configurations
+// to run check:construction.
+type ConstructionConfiguration struct {
+	Network               *types.NetworkIdentifier `json:"network"`
+	OfflineURL            string                   `json:"offline_url"`
+	Currency              *types.Currency          `json:"currency"`
+	MinimumAccountBalance string                   `json:"minimum_account_balance"`
+	MinimumFee            string                   `json:"minimum_fee"`
+	MaximumFee            string                   `json:"maximum_fee"`
+	CurveType             types.CurveType          `json:"curve_type"`
+	AccountingModel       AccountingModel          `json:"accounting_model"`
+	TransferScenario      []*types.Operation       `json:"transfer_scenario"`
+}
+
+// DataConfiguration contains all configurations to run check:data.
+type DataConfiguration struct{} // TODO: Populate and Assert DataConfiguration, Add end conditions, populate defaults that aren't filled in
+
+// Configuration contains all configuration settings for running
+// check:data or check:construction.
+type Configuration struct {
+	OnlineURL    string                     `json:"online_url"`
+	Construction *ConstructionConfiguration `json:"construction"`
+	Data         *DataConfiguration         `json:"data"`
+}
+
+func assertConstructionConfiguration(config *ConstructionConfiguration) error {
+	switch config.AccountingModel {
+	case AccountModel, UtxoModel:
+	default:
+		return fmt.Errorf("accounting model %s not supported", config.AccountingModel)
+	}
+
+	if err := asserter.CurveType(config.CurveType); err != nil {
+		return fmt.Errorf("%w: invalid curve type", err)
+	}
+
+	return nil
+}
+
+// LoadConfiguration returns a parsed and asserted Configuration for running
+// tests.
+func LoadConfiguration(filePath string, mode TestingMode) (*Configuration, error) {
+	var config Configuration
+	if err := utils.LoadAndParse(filePath, &config); err != nil {
+		return nil, fmt.Errorf("%w: unable to open configuration file", err)
+	}
+
+	switch mode {
+	case ConstructionMode:
+		if err := assertConstructionConfiguration(config.Construction); err != nil {
+			return nil, fmt.Errorf("%w: invalid construction configuration", err)
+		}
+	case DataMode, ViewMode:
+	default:
+		return nil, fmt.Errorf("testing more %s not supported", mode)
+	}
+
+	log.Printf(
+		"loaded configuration file: %s\n",
+		types.PrettyPrintStruct(config),
+	)
+
+	return &config, nil
+}
+
+// TODO: Create Default Configuration File (print out all defaults to the console
+// so it is easy for someone to create their own...print out settings for ETH Construction API).

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -50,17 +50,24 @@ const (
 	DefaultActiveReconciliationConcurrency   = 16
 	DefaultInactiveReconciliationConcurrency = 4
 	DefaultInactiveReconciliationFrequency   = 250
+
+	// ETH Defaults
+	EthereumBlockchain = "Ethereum"
+	EthereumNetwork    = "Ropsten"
+	EthereumTransfer   = "transfer"
+	EthereumSymbol     = "ETH"
+	EthereumDecimals   = 18
 )
 
 // Default Configuration Values
 var (
 	DefaultNetwork = &types.NetworkIdentifier{
-		Blockchain: "Ethereum",
-		Network:    "Ropsten",
+		Blockchain: EthereumBlockchain,
+		Network:    EthereumNetwork,
 	}
 	DefaultCurrency = &types.Currency{
-		Symbol:   "ETH",
-		Decimals: 18,
+		Symbol:   EthereumSymbol,
+		Decimals: EthereumDecimals,
 	}
 	DefaultTransferScenario = []*types.Operation{
 		{
@@ -70,7 +77,7 @@ var (
 			Account: &types.AccountIdentifier{
 				Address: scenario.Sender,
 			},
-			Type: "transfer",
+			Type: EthereumTransfer,
 			Amount: &types.Amount{
 				Value: scenario.SenderValue,
 			},
@@ -87,7 +94,7 @@ var (
 			Account: &types.AccountIdentifier{
 				Address: scenario.Recipient,
 			},
-			Type: "transfer",
+			Type: EthereumTransfer,
 			Amount: &types.Amount{
 				Value: scenario.RecipientValue,
 			},
@@ -420,8 +427,8 @@ func LoadConfiguration(filePath string) (*Configuration, error) {
 	}
 
 	log.Printf(
-		"loaded configuration: %s\n",
-		types.PrettyPrintStruct(config),
+		"loaded configuration file: %s\n",
+		filePath,
 	)
 
 	return config, nil

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package configuration
 
 import (
@@ -81,7 +95,8 @@ var (
 	}
 )
 
-// TODO: Add support for sophisticated end conditions (https://github.com/coinbase/rosetta-cli/issues/66)
+// TODO: Add support for sophisticated end conditions
+// (https://github.com/coinbase/rosetta-cli/issues/66)
 
 // ConstructionConfiguration contains all configurations
 // to run check:construction.
@@ -257,7 +272,9 @@ type Configuration struct {
 	Data         *DataConfiguration         `json:"data"`
 }
 
-func populateConstructionMissingFields(constructionConfig *ConstructionConfiguration) *ConstructionConfiguration {
+func populateConstructionMissingFields(
+	constructionConfig *ConstructionConfiguration,
+) *ConstructionConfiguration {
 	if constructionConfig == nil {
 		return DefaultConstructionConfiguration()
 	}
@@ -333,16 +350,15 @@ func populateDataMissingFields(dataConfig *DataConfiguration) *DataConfiguration
 	return dataConfig
 }
 
-func populateMissingFields(config *Configuration) {
+func populateMissingFields(config *Configuration) *Configuration {
 	if config == nil {
-		config = DefaultConfiguration()
-		return
+		return DefaultConfiguration()
 	}
 
 	config.Construction = populateConstructionMissingFields(config.Construction)
 	config.Data = populateDataMissingFields(config.Data)
 
-	return
+	return config
 }
 
 func checkStringUint(input string) error {
@@ -392,12 +408,12 @@ func assertConstructionConfiguration(config *ConstructionConfiguration) error {
 // LoadConfiguration returns a parsed and asserted Configuration for running
 // tests.
 func LoadConfiguration(filePath string) (*Configuration, error) {
-	var config Configuration
-	if err := utils.LoadAndParse(filePath, &config); err != nil {
+	var configRaw Configuration
+	if err := utils.LoadAndParse(filePath, &configRaw); err != nil {
 		return nil, fmt.Errorf("%w: unable to open configuration file", err)
 	}
 
-	populateMissingFields(&config)
+	config := populateMissingFields(&configRaw)
 
 	if err := assertConstructionConfiguration(config.Construction); err != nil {
 		return nil, fmt.Errorf("%w: invalid construction configuration", err)
@@ -408,5 +424,5 @@ func LoadConfiguration(filePath string) (*Configuration, error) {
 		types.PrettyPrintStruct(config),
 	)
 
-	return &config, nil
+	return config, nil
 }

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -1,0 +1,42 @@
+package configuration
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/coinbase/rosetta-cli/internal/utils"
+
+	// "github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadConfiguration(t *testing.T) {
+	var tests = map[string]struct {
+		provided *Configuration
+		expected *Configuration
+	}{
+		"nothing provided": {
+			provided: &Configuration{},
+			expected: DefaultConfiguration(),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Write configuration file to tempdir
+			tmpfile, err := ioutil.TempFile("", "test.json")
+			assert.NoError(t, err)
+			defer os.Remove(tmpfile.Name())
+
+			err = utils.SerializeAndWrite(tmpfile.Name(), test.provided)
+			assert.NoError(t, err)
+
+			// Check if expected fields populated
+			config, err := LoadConfiguration(tmpfile.Name())
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, config)
+			assert.NoError(t, tmpfile.Close())
+		})
+	}
+}

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package configuration
 
 import (

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -7,18 +7,112 @@ import (
 
 	"github.com/coinbase/rosetta-cli/internal/utils"
 
-	// "github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/assert"
+)
+
+var (
+	whackyConfig = &Configuration{
+		Construction: &ConstructionConfiguration{
+			Network: &types.NetworkIdentifier{
+				Blockchain: "sweet",
+				Network:    "sweeter",
+			},
+			OnlineURL:  "http://hasudhasjkdk",
+			OfflineURL: "https://ashdjaksdkjshdk",
+			Currency: &types.Currency{
+				Symbol:   "FIRE",
+				Decimals: 100,
+			},
+			MinimumBalance:   "1002",
+			MaximumFee:       "1",
+			CurveType:        types.Edwards25519,
+			AccountingModel:  UtxoModel,
+			TransferScenario: DefaultTransferScenario,
+		},
+		Data: &DataConfiguration{
+			OnlineURL:                         "https://asjdlkasjdklajsdlkj",
+			BlockConcurrency:                  12,
+			TransactionConcurrency:            2,
+			ActiveReconciliationConcurrency:   100,
+			InactiveReconciliationConcurrency: 2938,
+			InactiveReconciliationFrequency:   3,
+		},
+	}
+	invalidNetwork = &Configuration{
+		Construction: &ConstructionConfiguration{
+			Network: &types.NetworkIdentifier{
+				Blockchain: "?",
+			},
+		},
+	}
+	invalidCurrency = &Configuration{
+		Construction: &ConstructionConfiguration{
+			Currency: &types.Currency{
+				Decimals: 12,
+			},
+		},
+	}
+	invalidCurve = &Configuration{
+		Construction: &ConstructionConfiguration{
+			CurveType: "hello",
+		},
+	}
+	invalidAccountingModel = &Configuration{
+		Construction: &ConstructionConfiguration{
+			AccountingModel: "hello",
+		},
+	}
+	invalidMinimumBalance = &Configuration{
+		Construction: &ConstructionConfiguration{
+			MinimumBalance: "-1000",
+		},
+	}
+	invalidMaximumFee = &Configuration{
+		Construction: &ConstructionConfiguration{
+			MaximumFee: "hello",
+		},
+	}
 )
 
 func TestLoadConfiguration(t *testing.T) {
 	var tests = map[string]struct {
 		provided *Configuration
 		expected *Configuration
+
+		err bool
 	}{
 		"nothing provided": {
 			provided: &Configuration{},
 			expected: DefaultConfiguration(),
+		},
+		"no overwrite": {
+			provided: whackyConfig,
+			expected: whackyConfig,
+		},
+		"invalid network": {
+			provided: invalidNetwork,
+			err:      true,
+		},
+		"invalid currency": {
+			provided: invalidCurrency,
+			err:      true,
+		},
+		"invalid curve type": {
+			provided: invalidCurve,
+			err:      true,
+		},
+		"invalid accounting model": {
+			provided: invalidAccountingModel,
+			err:      true,
+		},
+		"invalid minimum balance": {
+			provided: invalidMinimumBalance,
+			err:      true,
+		},
+		"invalid maximum fee": {
+			provided: invalidMaximumFee,
+			err:      true,
 		},
 	}
 
@@ -34,8 +128,13 @@ func TestLoadConfiguration(t *testing.T) {
 
 			// Check if expected fields populated
 			config, err := LoadConfiguration(tmpfile.Name())
-			assert.NoError(t, err)
-			assert.Equal(t, test.expected, config)
+			if test.err {
+				assert.Error(t, err)
+				assert.Nil(t, config)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, config)
+			}
 			assert.NoError(t, tmpfile.Close())
 		})
 	}

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6/go.mod h1:Dmm/EzmjnCiweXmzRIAiUWCInVmPgjkzgv5k4tVyXiQ=
+github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
@@ -354,6 +355,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -23,6 +23,7 @@ import (
 	"path"
 
 	"github.com/coinbase/rosetta-cli/internal/storage"
+	"github.com/coinbase/rosetta-cli/internal/utils"
 
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/reconciler"
@@ -55,10 +56,6 @@ const (
 	// removeEvent is printed in a stream
 	// when an event is orphaned.
 	removeEvent = "Remove"
-
-	// logFilePermissions specifies that the user can
-	// read and write the file.
-	logFilePermissions = 0600
 )
 
 // Logger contains all logic to record validator output
@@ -155,7 +152,7 @@ func (l *Logger) AddBlockStream(
 	f, err := os.OpenFile(
 		path.Join(l.logDir, blockStreamFile),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
-		logFilePermissions,
+		os.FileMode(utils.DefaultFilePermissions),
 	)
 	if err != nil {
 		return err
@@ -191,7 +188,7 @@ func (l *Logger) RemoveBlockStream(
 	f, err := os.OpenFile(
 		path.Join(l.logDir, blockStreamFile),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
-		logFilePermissions,
+		os.FileMode(utils.DefaultFilePermissions),
 	)
 	if err != nil {
 		return err
@@ -225,7 +222,7 @@ func (l *Logger) TransactionStream(
 	f, err := os.OpenFile(
 		path.Join(l.logDir, transactionStreamFile),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
-		logFilePermissions,
+		os.FileMode(utils.DefaultFilePermissions),
 	)
 	if err != nil {
 		return err
@@ -293,7 +290,7 @@ func (l *Logger) BalanceStream(
 	f, err := os.OpenFile(
 		path.Join(l.logDir, balanceStreamFile),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
-		logFilePermissions,
+		os.FileMode(utils.DefaultFilePermissions),
 	)
 	if err != nil {
 		return err
@@ -335,7 +332,7 @@ func (l *Logger) ReconcileSuccessStream(
 	f, err := os.OpenFile(
 		path.Join(l.logDir, reconcileSuccessStreamFile),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
-		logFilePermissions,
+		os.FileMode(utils.DefaultFilePermissions),
 	)
 	if err != nil {
 		return err
@@ -406,7 +403,7 @@ func (l *Logger) ReconcileFailureStream(
 	f, err := os.OpenFile(
 		path.Join(l.logDir, reconcileFailureStreamFile),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
-		logFilePermissions,
+		os.FileMode(utils.DefaultFilePermissions),
 	)
 	if err != nil {
 		return err

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -26,6 +26,12 @@ import (
 	"github.com/fatih/color"
 )
 
+const (
+	// DefaultFilePermissions specifies that the user can
+	// read and write the file.
+	DefaultFilePermissions = 0600
+)
+
 // CreateTempDir creates a directory in
 // /tmp for usage within testing.
 func CreateTempDir() (string, error) {
@@ -52,8 +58,24 @@ func Equal(a interface{}, b interface{}) bool {
 	return types.Hash(a) == types.Hash(b)
 }
 
+// SerializeAndWrite attempts to serialize the provided object
+// into a file at filePath.
+func SerializeAndWrite(filePath string, object interface{}) error {
+	bytes, err := json.Marshal(object)
+	if err != nil {
+		return fmt.Errorf("%w: unable to serialize object", err)
+	}
+
+	err = ioutil.WriteFile(filePath, bytes, os.FileMode(DefaultFilePermissions))
+	if err != nil {
+		return fmt.Errorf("%w: unable to write to file path %s", err, filePath)
+	}
+
+	return nil
+}
+
 // LoadAndParse reads the file at the provided path
-// and attempts to marshal it into output.
+// and attempts to unmarshal it into output.
 func LoadAndParse(filePath string, output interface{}) error {
 	bytes, err := ioutil.ReadFile(path.Clean(filePath))
 	if err != nil {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -15,9 +15,12 @@
 package utils
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/fatih/color"
@@ -47,4 +50,19 @@ func RemoveTempDir(dir string) {
 // interfaces are equal.
 func Equal(a interface{}, b interface{}) bool {
 	return types.Hash(a) == types.Hash(b)
+}
+
+// LoadAndParse reads the file at the provided path
+// and attempts to marshal it into output.
+func LoadAndParse(filePath string, output interface{}) error {
+	bytes, err := ioutil.ReadFile(path.Clean(filePath))
+	if err != nil {
+		return fmt.Errorf("%w: unable to load file %s", err, filePath)
+	}
+
+	if err := json.Unmarshal(bytes, &output); err != nil {
+		return fmt.Errorf("%w: unable to unmarshal", err)
+	}
+
+	return nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -61,12 +61,11 @@ func Equal(a interface{}, b interface{}) bool {
 // SerializeAndWrite attempts to serialize the provided object
 // into a file at filePath.
 func SerializeAndWrite(filePath string, object interface{}) error {
-	bytes, err := json.Marshal(object)
-	if err != nil {
-		return fmt.Errorf("%w: unable to serialize object", err)
-	}
-
-	err = ioutil.WriteFile(filePath, bytes, os.FileMode(DefaultFilePermissions))
+	err := ioutil.WriteFile(
+		filePath,
+		[]byte(types.PrettyPrintStruct(object)),
+		os.FileMode(DefaultFilePermissions),
+	)
 	if err != nil {
 		return fmt.Errorf("%w: unable to write to file path %s", err, filePath)
 	}


### PR DESCRIPTION
Fixes: #47 
Related PR: #68 

### Changes
* Add `--configuration-file` flag (any missing fields populated by defaults)
* Rearrange commands to:
  * `check` -> `check:data`
  * `check:construction` (not implemented yet)
  * `configuration:create <filePath>` (creates a default configuration file at the `filePath`)
  * `configuration:validate <filePath>` (ensures the configuration file at `filePath` is correctly formulated)
  * `create:configuration` -> `utils:asserter-configuration`
