### PR TITLE
Coin Storage (automated UTXO tracking)

### DIFF
--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -414,7 +414,6 @@ func (b *BlockStorage) storeTransactionHash(
 	var blocks map[string]int64
 	if !exists {
 		blocks = make(map[string]int64)
-		blocks[blockIdentifier.Hash] = blockIdentifier.Index
 	} else {
 		if err := decode(val, &blocks); err != nil {
 			return fmt.Errorf("%w: could not decode transaction hash contents", err)
@@ -429,9 +428,8 @@ func (b *BlockStorage) storeTransactionHash(
 				blockIdentifier.Index,
 			)
 		}
-
-		blocks[blockIdentifier.Hash] = blockIdentifier.Index
 	}
+	blocks[blockIdentifier.Hash] = blockIdentifier.Index
 
 	encodedResult, err := encode(blocks)
 	if err != nil {

--- a/internal/storage/coin_storage.go
+++ b/internal/storage/coin_storage.go
@@ -115,7 +115,6 @@ func (c *CoinStorage) tryAddingCoin(ctx context.Context, transaction DatabaseTra
 				return fmt.Errorf("coin %s already exists in account %s", coinIdentifier, types.PrettyPrintStruct(operation.Account))
 			}
 		}
-
 		coins[coinIdentifier] = struct{}{}
 
 		if err := encodeAndSetCoins(ctx, transaction, operation.Account, coins); err != nil {

--- a/internal/storage/coin_storage.go
+++ b/internal/storage/coin_storage.go
@@ -1,0 +1,163 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+const (
+	coinNamespace        = "coinNamespace"
+	coinAccountNamespace = "coinAccountNamespace"
+
+	coinCreated = "utxo_created"
+	coinSpent   = "utxo_spent"
+)
+
+var _ BlockWorker = (*CoinStorage)(nil)
+
+// CoinStorage implements storage methods for storing
+// UTXOs.
+type CoinStorage struct {
+	db Database
+}
+
+// NewCoinStorage returns a new CoinStorage.
+func NewCoinStorage(
+	db Database,
+) *CoinStorage {
+	return &CoinStorage{
+		db: db,
+	}
+}
+
+type Coin struct {
+	Identifier  string             `json:"identifier"` // uses "utxo_created" or "utxo_spent"
+	Transaction *types.Transaction `json:"transaction"`
+	Operation   *types.Operation   `json:"operation"`
+}
+
+type CoinAccount struct {
+	Coins []string `json:"coins"` // a slice of coin identifiers
+}
+
+func getCoinKey(identifier string) []byte {
+	return []byte(fmt.Sprintf("%s/%s", coinNamespace, identifier))
+}
+
+func getCoinAccountKey(address string) []byte {
+	return []byte(fmt.Sprintf("%s/%s", coinAccountNamespace, address))
+}
+
+func (c *CoinStorage) tryAddingCoin(ctx context.Context, transaction DatabaseTransaction, blockTransaction *types.Transaction, operation *types.Operation, identiferKey string) error {
+	rawIdentifier, ok := operation.Metadata[identiferKey]
+	if ok {
+		coinIdentifier, ok := rawIdentifier.(string)
+		if !ok {
+			return fmt.Errorf("unable to parse created coin %v", rawIdentifier)
+		}
+
+		newCoin := &Coin{
+			Identifier:  coinIdentifier,
+			Transaction: blockTransaction,
+			Operation:   operation,
+		}
+
+		encodedResult, err := encode(newCoin)
+		if err != nil {
+			return fmt.Errorf("%w: unable to encode coin data", err)
+		}
+
+		if err := transaction.Set(ctx, getCoinKey(coinIdentifier), encodedResult); err != nil {
+			return fmt.Errorf("%w: unable to store coin", err)
+		}
+
+		// TODO: need to link UTXOs with Accounts
+	}
+
+	return nil
+}
+
+func (c *CoinStorage) tryRemovingCoin(ctx context.Context, transaction DatabaseTransaction, blockTransaction *types.Transaction, operation *types.Operation, identiferKey string) error {
+	rawIdentifier, ok := operation.Metadata[identiferKey]
+	if ok {
+		coinIdentifier, ok := rawIdentifier.(string)
+		if !ok {
+			return fmt.Errorf("unable to parse spent coin %v", rawIdentifier)
+		}
+
+		exists, _, err := transaction.Get(ctx, getCoinKey(coinIdentifier))
+		if err != nil {
+			return fmt.Errorf("%w: unable to query for coin", err)
+		}
+
+		if !exists { // this could occur if coin was created before we started syncing
+			return nil
+		}
+
+		if err := transaction.Delete(ctx, getCoinKey(coinIdentifier)); err != nil {
+			return fmt.Errorf("%w: unable to delete coin", err)
+		}
+
+		// TODO: need to link UTXOs with Accounts
+	}
+
+	return nil
+}
+
+func (c *CoinStorage) AddingBlock(
+	ctx context.Context,
+	block *types.Block,
+	transaction DatabaseTransaction,
+) (CommitWorker, error) {
+	for _, txn := range block.Transactions {
+		for _, operation := range txn.Operations {
+			if err := c.tryAddingCoin(ctx, transaction, txn, operation, coinCreated); err != nil {
+				return nil, fmt.Errorf("%w: unable to add coin", err)
+			}
+
+			if err := c.tryRemovingCoin(ctx, transaction, txn, operation, coinSpent); err != nil {
+				return nil, fmt.Errorf("%w: unable to remove coin", err)
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func (c *CoinStorage) RemovingBlock(
+	ctx context.Context,
+	block *types.Block,
+	transaction DatabaseTransaction,
+) (CommitWorker, error) {
+	for _, txn := range block.Transactions {
+		for _, operation := range txn.Operations {
+			if err := c.tryAddingCoin(ctx, transaction, txn, operation, coinSpent); err != nil {
+				return nil, fmt.Errorf("%w: unable to add coin", err)
+			}
+
+			if err := c.tryRemovingCoin(ctx, transaction, txn, operation, coinCreated); err != nil {
+				return nil, fmt.Errorf("%w: unable to remove coin", err)
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// func (c *CoinStorage) Balance(address string) {}

--- a/internal/storage/coin_storage.go
+++ b/internal/storage/coin_storage.go
@@ -25,6 +25,10 @@ const (
 	coinNamespace        = "coinNamespace"
 	coinAccountNamespace = "coinAccountNamespace"
 
+	// For UTXOs to be recognized by CoinStorage, they must contain
+	// coinCreated or coinSpent in the Operation.Metadata with a value
+	// of the unique identifier of the coin. In Bitcoin, this unique
+	// identifier would be the outpoint (tx_hash:index).
 	coinCreated = "utxo_created"
 	coinSpent   = "utxo_spent"
 )

--- a/internal/storage/coin_storage.go
+++ b/internal/storage/coin_storage.go
@@ -46,6 +46,8 @@ func NewCoinStorage(
 	}
 }
 
+// Coin represents some spendable output (typically
+// referred to as a UTXO).
 type Coin struct {
 	Identifier  string             `json:"identifier"` // uses "utxo_created" or "utxo_spent"
 	Transaction *types.Transaction `json:"transaction"`
@@ -198,6 +200,7 @@ func (c *CoinStorage) tryRemovingCoin(ctx context.Context, transaction DatabaseT
 	return nil
 }
 
+// AddingBlock is called by BlockStorage when adding a block.
 func (c *CoinStorage) AddingBlock(
 	ctx context.Context,
 	block *types.Block,
@@ -222,6 +225,7 @@ func (c *CoinStorage) AddingBlock(
 	return nil, nil
 }
 
+// RemovingBlock is called by BlockStorage when removing a block.
 func (c *CoinStorage) RemovingBlock(
 	ctx context.Context,
 	block *types.Block,
@@ -233,6 +237,8 @@ func (c *CoinStorage) RemovingBlock(
 				continue
 			}
 
+			// We add spent coins and remove created coins during a re-org (opposite of
+			// AddingBlock).
 			if err := c.tryAddingCoin(ctx, transaction, txn, operation, coinSpent); err != nil {
 				return nil, fmt.Errorf("%w: unable to add coin", err)
 			}
@@ -246,6 +252,7 @@ func (c *CoinStorage) RemovingBlock(
 	return nil, nil
 }
 
+// GetCoins returns all unspent coins for a provided *types.AccountIdentifier.
 func (c *CoinStorage) GetCoins(ctx context.Context, accountIdentifier *types.AccountIdentifier) ([]*Coin, error) {
 	transaction := c.db.NewDatabaseTransaction(ctx, false)
 	defer transaction.Discard(ctx)

--- a/internal/storage/coin_storage.go
+++ b/internal/storage/coin_storage.go
@@ -110,12 +110,13 @@ func (c *CoinStorage) tryAddingCoin(ctx context.Context, transaction DatabaseTra
 
 		if !accountExists {
 			coins = map[string]struct{}{}
-			coins[coinIdentifier] = struct{}{}
 		} else {
 			if _, exists := coins[coinIdentifier]; exists {
 				return fmt.Errorf("coin %s already exists in account %s", coinIdentifier, types.PrettyPrintStruct(operation.Account))
 			}
 		}
+
+		coins[coinIdentifier] = struct{}{}
 
 		if err := encodeAndSetCoins(ctx, transaction, operation.Account, coins); err != nil {
 			return fmt.Errorf("%w: unable to set coin account", err)

--- a/internal/storage/coin_storage.go
+++ b/internal/storage/coin_storage.go
@@ -52,10 +52,6 @@ type Coin struct {
 	Operation   *types.Operation   `json:"operation"`
 }
 
-type CoinAccount struct {
-	Coins []string `json:"coins"` // a slice of coin identifiers
-}
-
 func getCoinKey(identifier string) []byte {
 	return []byte(fmt.Sprintf("%s/%s", coinNamespace, identifier))
 }

--- a/internal/storage/coin_storage_test.go
+++ b/internal/storage/coin_storage_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coinbase/rosetta-cli/internal/utils"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	account = &types.AccountIdentifier{
+		Address: "blah",
+	}
+)
+
+func TestCoinStorage(t *testing.T) {
+	ctx := context.Background()
+
+	newDir, err := utils.CreateTempDir()
+	assert.NoError(t, err)
+	defer utils.RemoveTempDir(newDir)
+
+	database, err := NewBadgerStorage(ctx, newDir)
+	assert.NoError(t, err)
+	defer database.Close(ctx)
+
+	c := NewCoinStorage(database)
+
+	t.Run("get coins of unset account", func(t *testing.T) {
+		coins, err := c.GetCoins(ctx, account)
+		assert.NoError(t, err)
+		assert.Equal(t, []*Coin{}, coins)
+	})
+}


### PR DESCRIPTION
Related PR: #68 

To support automated testing of UTXO-based blockchains, we need to provide coin tracking support.

### Changes
This PR introduces `CoinStorage` as a `BlockWorker` that automatically tracks coins that put either `utxo_created` or `utxo_spent` in the `Operation.Metadata`.