### PR TITLE
Update Configuration + Configurable Timeout

### DIFF
--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -119,8 +119,7 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 		fetcher,
 		cancel,
 		networkStatus.GenesisBlockIdentifier,
-		!Config.Data.ReconciliationDisabled,
-		nil,
+		nil, // only populated when doing recursive search
 		&SignalReceived,
 	)
 
@@ -151,7 +150,5 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 
 	// HandleErr will exit if we should not attempt
 	// to find missing operations.
-	dataTester.HandleErr(ctx, err)
-
-	dataTester.FindMissingOps(ctx, sigListeners)
+	dataTester.HandleErr(ctx, err, sigListeners)
 }

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -94,7 +94,7 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	fetcher := fetcher.New(
-		Config.Data.OnlineURL,
+		Config.OnlineURL,
 		fetcher.WithBlockConcurrency(Config.Data.BlockConcurrency),
 		fetcher.WithTransactionConcurrency(Config.Data.TransactionConcurrency),
 		fetcher.WithRetryElapsedTime(ExtendedRetryElapsedTime),

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -153,6 +153,5 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 	// to find missing operations.
 	dataTester.HandleErr(ctx, err)
 
-	// TODO: make configurable to run
 	dataTester.FindMissingOps(ctx, sigListeners)
 }

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/coinbase/rosetta-cli/internal/tester"
 
@@ -98,6 +99,7 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 		fetcher.WithBlockConcurrency(Config.Data.BlockConcurrency),
 		fetcher.WithTransactionConcurrency(Config.Data.TransactionConcurrency),
 		fetcher.WithRetryElapsedTime(ExtendedRetryElapsedTime),
+		fetcher.WithTimeout(time.Duration(Config.HTTPTimeout)*time.Second),
 	)
 
 	// TODO: sync and reconcile on subnetworks, if they exist.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,13 +112,13 @@ func initConfig() {
 func ensureDataDirectoryExists() {
 	// If data directory is not specified, we use a temporary directory
 	// and delete its contents when execution is complete.
-	if len(Config.Data.DataDirectory) == 0 {
+	if len(Config.DataDirectory) == 0 {
 		tmpDir, err := utils.CreateTempDir()
 		if err != nil {
 			log.Fatalf("%s: unable to create temporary directory", err.Error())
 		}
 
-		Config.Data.DataDirectory = tmpDir
+		Config.DataDirectory = tmpDir
 	}
 }
 

--- a/cmd/utils_asserter_configuration.go
+++ b/cmd/utils_asserter_configuration.go
@@ -46,7 +46,7 @@ func runCreateConfigurationCmd(cmd *cobra.Command, args []string) {
 
 	// Create a new fetcher
 	newFetcher := fetcher.New(
-		Config.Data.OnlineURL,
+		Config.OnlineURL,
 	)
 
 	// Initialize the fetcher's asserter

--- a/cmd/utils_asserter_configuration.go
+++ b/cmd/utils_asserter_configuration.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/coinbase/rosetta-cli/internal/utils"
 
@@ -47,6 +48,8 @@ func runCreateConfigurationCmd(cmd *cobra.Command, args []string) {
 	// Create a new fetcher
 	newFetcher := fetcher.New(
 		Config.OnlineURL,
+		fetcher.WithRetryElapsedTime(ExtendedRetryElapsedTime),
+		fetcher.WithTimeout(time.Duration(Config.HTTPTimeout)*time.Second),
 	)
 
 	// Initialize the fetcher's asserter

--- a/cmd/view_account.go
+++ b/cmd/view_account.go
@@ -58,7 +58,7 @@ func runViewAccountCmd(cmd *cobra.Command, args []string) {
 
 	// Create a new fetcher
 	newFetcher := fetcher.New(
-		Config.Data.OnlineURL,
+		Config.OnlineURL,
 	)
 
 	// Initialize the fetcher's asserter

--- a/cmd/view_account.go
+++ b/cmd/view_account.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/coinbase/rosetta-cli/internal/utils"
+
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -65,14 +67,15 @@ func runViewAccountCmd(cmd *cobra.Command, args []string) {
 	)
 
 	// Initialize the fetcher's asserter
-	primaryNetwork, _, err := newFetcher.InitializeAsserter(ctx)
+	_, _, err := newFetcher.InitializeAsserter(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Print the primary network and network status
-	// TODO: support specifying which network to get block from
-	log.Printf("Primary Network: %s\n", types.PrettyPrintStruct(primaryNetwork))
+	_, err = utils.CheckNetworkSupported(ctx, Config.Network, newFetcher)
+	if err != nil {
+		log.Fatalf("%s: unable to confirm network is supported", err.Error())
+	}
 
 	var lookupBlock *types.PartialBlockIdentifier
 	if len(args) > 1 {
@@ -86,7 +89,7 @@ func runViewAccountCmd(cmd *cobra.Command, args []string) {
 
 	block, amounts, metadata, err := newFetcher.AccountBalanceRetry(
 		ctx,
-		primaryNetwork,
+		Config.Network,
 		account,
 		lookupBlock,
 	)

--- a/cmd/view_account.go
+++ b/cmd/view_account.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
@@ -59,6 +60,8 @@ func runViewAccountCmd(cmd *cobra.Command, args []string) {
 	// Create a new fetcher
 	newFetcher := fetcher.New(
 		Config.OnlineURL,
+		fetcher.WithRetryElapsedTime(ExtendedRetryElapsedTime),
+		fetcher.WithTimeout(time.Duration(Config.HTTPTimeout)*time.Second),
 	)
 
 	// Initialize the fetcher's asserter

--- a/cmd/view_block.go
+++ b/cmd/view_block.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/parser"
@@ -54,6 +55,8 @@ func runViewBlockCmd(cmd *cobra.Command, args []string) {
 	// Create a new fetcher
 	newFetcher := fetcher.New(
 		Config.OnlineURL,
+		fetcher.WithRetryElapsedTime(ExtendedRetryElapsedTime),
+		fetcher.WithTimeout(time.Duration(Config.HTTPTimeout)*time.Second),
 	)
 
 	// Initialize the fetcher's asserter

--- a/cmd/view_block.go
+++ b/cmd/view_block.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/coinbase/rosetta-cli/internal/utils"
+
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -64,14 +66,15 @@ func runViewBlockCmd(cmd *cobra.Command, args []string) {
 	// Behind the scenes this makes a call to get the
 	// network status and uses the response to inform
 	// the asserter what are valid responses.
-	primaryNetwork, _, err := newFetcher.InitializeAsserter(ctx)
+	_, _, err = newFetcher.InitializeAsserter(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Print the primary network and network status
-	// TODO: support specifying which network to get block from
-	log.Printf("Primary Network: %s\n", types.PrettyPrintStruct(primaryNetwork))
+	_, err = utils.CheckNetworkSupported(ctx, Config.Network, newFetcher)
+	if err != nil {
+		log.Fatalf("%s: unable to confirm network is supported", err.Error())
+	}
 
 	// Fetch the specified block with retries (automatically
 	// asserted for correctness)
@@ -84,7 +87,7 @@ func runViewBlockCmd(cmd *cobra.Command, args []string) {
 	// transactions.
 	block, err := newFetcher.BlockRetry(
 		ctx,
-		primaryNetwork,
+		Config.Network,
 		&types.PartialBlockIdentifier{
 			Index: &index,
 		},

--- a/cmd/view_block.go
+++ b/cmd/view_block.go
@@ -53,7 +53,7 @@ func runViewBlockCmd(cmd *cobra.Command, args []string) {
 
 	// Create a new fetcher
 	newFetcher := fetcher.New(
-		Config.Data.OnlineURL,
+		Config.OnlineURL,
 	)
 
 	// Initialize the fetcher's asserter

--- a/cmd/view_network.go
+++ b/cmd/view_network.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -41,7 +42,11 @@ not formatted correctly.`,
 func runViewNetworkCmd(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 
-	f := fetcher.New(Config.OnlineURL)
+	f := fetcher.New(
+		Config.OnlineURL,
+		fetcher.WithRetryElapsedTime(ExtendedRetryElapsedTime),
+		fetcher.WithTimeout(time.Duration(Config.HTTPTimeout)*time.Second),
+	)
 
 	// Attempt to fetch network list
 	networkList, err := f.NetworkListRetry(ctx, nil)

--- a/cmd/view_network.go
+++ b/cmd/view_network.go
@@ -41,7 +41,7 @@ not formatted correctly.`,
 func runViewNetworkCmd(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 
-	f := fetcher.New(Config.Data.OnlineURL)
+	f := fetcher.New(Config.OnlineURL)
 
 	// Attempt to fetch network list
 	networkList, err := f.NetworkListRetry(ctx, nil)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -172,6 +172,7 @@ func DefaultDataConfiguration() *DataConfiguration {
 }
 
 // DefaultConfiguration returns a *Configuration with the
+// EthereumNetwork, DefaultURL, DefaultTimeout,
 // DefaultConstructionConfiguration and DefaultDataConfiguration.
 func DefaultConfiguration() *Configuration {
 	return &Configuration{

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -264,6 +264,12 @@ type DataConfiguration struct {
 	// Note, a search will never be performed if historical balance lookup
 	// is disabled.
 	InactiveDiscrepencySearchDisabled bool `json:"inactive_discrepency_search_disabled"`
+
+	// BalanceTrackingDisabled is a boolean that indicates balances calculation
+	// should not be attempted. When first testing an implemenation, it can be
+	// useful to just try to fetch all blocks before checking for balance
+	// consistency.
+	BalanceTrackingDisabled bool `json:"balance_tracking_disabled"`
 }
 
 // Configuration contains all configuration settings for running

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -184,7 +184,6 @@ func DefaultConfiguration() *Configuration {
 }
 
 // DataConfiguration contains all configurations to run check:data.
-// TODO: Add configurable timeout (https://github.com/coinbase/rosetta-cli/issues/64)
 type DataConfiguration struct {
 	// BlockConcurrency is the concurrency to use while fetching blocks.
 	// default: 8
@@ -259,6 +258,12 @@ type DataConfiguration struct {
 	// be attempted. When first testing an implementation, it can be useful to disable
 	// some of the more advanced checks to confirm syncing is working as expected.
 	ReconciliationDisabled bool `json:"reconciliation_disabled"`
+
+	// InactiveDiscrepencySearchDisabled is a boolean indicating if a search
+	// should be performed to find any inactive reconciliation discrepencies.
+	// Note, a search will never be performed if historical balance lookup
+	// is disabled.
+	InactiveDiscrepencySearchDisabled bool `json:"inactive_discrepency_search_disabled"`
 }
 
 // Configuration contains all configuration settings for running

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -27,12 +27,13 @@ import (
 
 var (
 	whackyConfig = &Configuration{
+		Network: &types.NetworkIdentifier{
+			Blockchain: "sweet",
+			Network:    "sweeter",
+		},
+		OnlineURL:   "http://hasudhasjkdk",
+		HTTPTimeout: 21,
 		Construction: &ConstructionConfiguration{
-			Network: &types.NetworkIdentifier{
-				Blockchain: "sweet",
-				Network:    "sweeter",
-			},
-			OnlineURL:  "http://hasudhasjkdk",
 			OfflineURL: "https://ashdjaksdkjshdk",
 			Currency: &types.Currency{
 				Symbol:   "FIRE",
@@ -42,22 +43,21 @@ var (
 			MaximumFee:       "1",
 			CurveType:        types.Edwards25519,
 			AccountingModel:  UtxoModel,
-			TransferScenario: DefaultTransferScenario,
+			TransferScenario: EthereumTransfer,
 		},
 		Data: &DataConfiguration{
-			OnlineURL:                         "https://asjdlkasjdklajsdlkj",
 			BlockConcurrency:                  12,
 			TransactionConcurrency:            2,
 			ActiveReconciliationConcurrency:   100,
 			InactiveReconciliationConcurrency: 2938,
 			InactiveReconciliationFrequency:   3,
+			ReconciliationDisabled:            true,
+			HistoricalBalanceDisabled:         true,
 		},
 	}
 	invalidNetwork = &Configuration{
-		Construction: &ConstructionConfiguration{
-			Network: &types.NetworkIdentifier{
-				Blockchain: "?",
-			},
+		Network: &types.NetworkIdentifier{
+			Blockchain: "?",
 		},
 	}
 	invalidCurrency = &Configuration{

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
-	github.com/coinbase/rosetta-sdk-go v0.3.3-0.20200720162936-f929bfc4a262
+	github.com/coinbase/rosetta-sdk-go v0.3.3-0.20200725175621-613a0e5f950c
 	github.com/dgraph-io/badger v1.6.1
 	github.com/ethereum/go-ethereum v1.9.15
 	github.com/fatih/color v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod
 github.com/coinbase/rosetta-sdk-go v0.3.2 h1:2Fep2gIHBGDUNZVaRgSYp6KYfGeFbHp97OlJzw2YRsU=
 github.com/coinbase/rosetta-sdk-go v0.3.3-0.20200720162936-f929bfc4a262 h1:mMAn4TAc2uoY8UkWVQuo5PqR8PnZ9WRG+nw50RnHI8U=
 github.com/coinbase/rosetta-sdk-go v0.3.3-0.20200720162936-f929bfc4a262/go.mod h1:xTq9qdqHVg6uA87pMUJLE+PqyXFM4PyqOY79J8MCNGA=
+github.com/coinbase/rosetta-sdk-go v0.3.3-0.20200725175621-613a0e5f950c h1:FQZvtvvveeLADw1IPT2lDbbDJzAZ6TgGyqURCOyxjyI=
+github.com/coinbase/rosetta-sdk-go v0.3.3-0.20200725175621-613a0e5f950c/go.mod h1:xTq9qdqHVg6uA87pMUJLE+PqyXFM4PyqOY79J8MCNGA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -265,12 +265,12 @@ func (t *DataTester) StartPeriodicLogger(
 	ctx context.Context,
 ) error {
 	for ctx.Err() == nil {
-		_ = t.logger.LogCounterStorage(ctx)
+		_ = t.logger.LogDataStats(ctx)
 		time.Sleep(PeriodicLoggingFrequency)
 	}
 
 	// Print stats one last time before exiting
-	_ = t.logger.LogCounterStorage(ctx)
+	_ = t.logger.LogDataStats(ctx)
 
 	return ctx.Err()
 }
@@ -321,6 +321,11 @@ func (t *DataTester) HandleErr(ctx context.Context, err error) {
 // that is missing balance-changing operations for a
 // *reconciler.AccountCurrency.
 func (t *DataTester) FindMissingOps(ctx context.Context, sigListeners []context.CancelFunc) {
+	if t.config.Data.InactiveDiscrepencySearchDisabled {
+		color.Red("Search for inactive reconciliation discrepency is disabled")
+		os.Exit(1)
+	}
+
 	color.Red("Searching for block with missing operations...hold tight")
 	badBlock, err := t.recursiveOpSearch(
 		ctx,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -101,3 +101,16 @@ func LoadAndParse(filePath string, output interface{}) error {
 
 	return nil
 }
+
+// CreateCommandPath creates a unique path for a command and network within a data directory. This
+// is used to avoid collision when using multiple commands on multiple networks
+// when the same storage resources are used. If the derived path does not exist,
+// we run os.MkdirAll on the path.
+func CreateCommandPath(dataDirectory string, cmd string, network *types.NetworkIdentifier) (string, error) {
+	dataPath := path.Join(dataDirectory, cmd, types.Hash(network))
+	if err := EnsurePathExists(dataPath); err != nil {
+		return "", fmt.Errorf("%w: cannot populate path", err)
+	}
+
+	return dataPath, nil
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -108,7 +108,11 @@ func LoadAndParse(filePath string, output interface{}) error {
 // is used to avoid collision when using multiple commands on multiple networks
 // when the same storage resources are used. If the derived path does not exist,
 // we run os.MkdirAll on the path.
-func CreateCommandPath(dataDirectory string, cmd string, network *types.NetworkIdentifier) (string, error) {
+func CreateCommandPath(
+	dataDirectory string,
+	cmd string,
+	network *types.NetworkIdentifier,
+) (string, error) {
 	dataPath := path.Join(dataDirectory, cmd, types.Hash(network))
 	if err := EnsurePathExists(dataPath); err != nil {
 		return "", fmt.Errorf("%w: cannot populate path", err)
@@ -119,7 +123,11 @@ func CreateCommandPath(dataDirectory string, cmd string, network *types.NetworkI
 
 // CheckNetworkSupported checks if a Rosetta implementation supports a given
 // *types.NetworkIdentifier. If it does, the current network status is returned.
-func CheckNetworkSupported(ctx context.Context, networkIdentifier *types.NetworkIdentifier, fetcher *fetcher.Fetcher) (*types.NetworkStatusResponse, error) {
+func CheckNetworkSupported(
+	ctx context.Context,
+	networkIdentifier *types.NetworkIdentifier,
+	fetcher *fetcher.Fetcher,
+) (*types.NetworkStatusResponse, error) {
 	networks, err := fetcher.NetworkList(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w: unable to fetch network list", err)


### PR DESCRIPTION
Fixes: #64 
Fixes: #48 
Fixes: #65 
Related PR: #68 

### Changes
- [x] cleanup config organization
- [x] Add function for creating a path for a command and network
- [x] Use provided timeout in all fetcher instantiations
- [x] Perform checks using provided network (need to confirm network supported)
- [x] Less verbose stats logging (only print if messaged changed)
- [x] configurable finder of reconciliation error
- [x] disable balance calculation