### PR TITLE
Add BroadcastStorage

### DIFF
--- a/internal/storage/balance_storage_test.go
+++ b/internal/storage/balance_storage_test.go
@@ -607,6 +607,8 @@ func TestBootstrapBalances(t *testing.T) {
 	})
 }
 
+var _ BalanceStorageHelper = (*MockBalanceStorageHelper)(nil)
+
 type MockBalanceStorageHelper struct {
 	AccountBalanceAmount string
 	AccountBalances      map[string]string

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math"
 
 	"github.com/coinbase/rosetta-sdk-go/syncer"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -479,8 +478,8 @@ func (b *BlockStorage) removeTransactionHash(
 }
 
 // FindTransaction returns the []*types.BlockIdentifier containing the
-// transaction and the depth from the current head of the first transaction
-// sigting (almost always this will just be a single block). If not found,
+// transaction and the depth from the current head of the last transaction
+// sighting (almost always this will just be a single block). If not found,
 // it returns a ErrTransactionNotFound error.
 func (b *BlockStorage) FindTransaction(
 	ctx context.Context,
@@ -522,13 +521,13 @@ func (b *BlockStorage) FindTransaction(
 	}
 
 	ids := []*types.BlockIdentifier{}
-	oldestBlock := int64(math.MaxInt64)
+	newestBlock := int64(0)
 	for hash, index := range blocks {
 		ids = append(ids, &types.BlockIdentifier{Hash: hash, Index: index})
-		if index < oldestBlock {
-			oldestBlock = index
+		if index > newestBlock {
+			newestBlock = index
 		}
 	}
 
-	return ids, head.Index - oldestBlock, nil
+	return ids, head.Index - newestBlock, nil
 }

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -525,5 +525,10 @@ func (b *BlockStorage) FindTransaction(
 		}
 	}
 
-	return nil, nil, fmt.Errorf("unable to find transaction %s in expected block %s:%d", transactionIdentifier.Hash, newestBlock.Hash, newestBlock.Index)
+	return nil, nil, fmt.Errorf(
+		"unable to find transaction %s in expected block %s:%d",
+		transactionIdentifier.Hash,
+		newestBlock.Hash,
+		newestBlock.Index,
+	)
 }

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -263,13 +263,13 @@ func TestBlock(t *testing.T) {
 	storage := NewBlockStorage(database)
 
 	t.Run("Get non-existent tx", func(t *testing.T) {
-		txBlocks, headDistance, err := storage.FindTransaction(
+		newestBlock, transaction, err := storage.FindTransaction(
 			ctx,
 			newBlock.Transactions[0].TransactionIdentifier,
 		)
 		assert.NoError(t, err)
-		assert.Nil(t, txBlocks)
-		assert.Equal(t, int64(-1), headDistance)
+		assert.Nil(t, newestBlock)
+		assert.Nil(t, transaction)
 	})
 
 	t.Run("Set and get block", func(t *testing.T) {
@@ -284,14 +284,13 @@ func TestBlock(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, newBlock.BlockIdentifier, head)
 
-		txBlocks, headDistance, err := storage.FindTransaction(
+		newestBlock, transaction, err := storage.FindTransaction(
 			ctx,
 			newBlock.Transactions[0].TransactionIdentifier,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, txBlocks, 1)
-		assert.Equal(t, newBlock.BlockIdentifier, txBlocks[0])
-		assert.Equal(t, int64(0), headDistance)
+		assert.Equal(t, newBlock.BlockIdentifier, newestBlock)
+		assert.Equal(t, newBlock.Transactions[0], transaction)
 	})
 
 	t.Run("Get non-existent block", func(t *testing.T) {
@@ -321,18 +320,13 @@ func TestBlock(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, newBlock2.BlockIdentifier, head)
 
-		txBlocks, headDistance, err := storage.FindTransaction(
+		newestBlock, transaction, err := storage.FindTransaction(
 			ctx,
 			newBlock.Transactions[0].TransactionIdentifier,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, txBlocks, 2)
-		assert.ElementsMatch(
-			t,
-			[]*types.BlockIdentifier{newBlock.BlockIdentifier, newBlock2.BlockIdentifier},
-			txBlocks,
-		)
-		assert.Equal(t, int64(0), headDistance)
+		assert.Equal(t, newBlock2.BlockIdentifier, newestBlock)
+		assert.Equal(t, newBlock2.Transactions[0], transaction)
 	})
 
 	t.Run("Remove block and re-set block of same hash", func(t *testing.T) {
@@ -350,18 +344,13 @@ func TestBlock(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, newBlock2.BlockIdentifier, head)
 
-		txBlocks, headDistance, err := storage.FindTransaction(
+		newestBlock, transaction, err := storage.FindTransaction(
 			ctx,
 			newBlock.Transactions[0].TransactionIdentifier,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, txBlocks, 2)
-		assert.ElementsMatch(
-			t,
-			[]*types.BlockIdentifier{newBlock.BlockIdentifier, newBlock2.BlockIdentifier},
-			txBlocks,
-		)
-		assert.Equal(t, int64(0), headDistance)
+		assert.Equal(t, newBlock2.BlockIdentifier, newestBlock)
+		assert.Equal(t, newBlock2.Transactions[0], transaction)
 	})
 
 	t.Run("Add block with complex metadata", func(t *testing.T) {
@@ -376,18 +365,13 @@ func TestBlock(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, complexBlock.BlockIdentifier, head)
 
-		txBlocks, headDistance, err := storage.FindTransaction(
+		newestBlock, transaction, err := storage.FindTransaction(
 			ctx,
 			newBlock.Transactions[0].TransactionIdentifier,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, txBlocks, 2)
-		assert.ElementsMatch(
-			t,
-			[]*types.BlockIdentifier{newBlock.BlockIdentifier, newBlock2.BlockIdentifier},
-			txBlocks,
-		)
-		assert.Equal(t, int64(1), headDistance)
+		assert.Equal(t, newBlock2.BlockIdentifier, newestBlock)
+		assert.Equal(t, newBlock2.Transactions[0], transaction)
 	})
 
 	t.Run("Set duplicate transaction hash (same block)", func(t *testing.T) {

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -332,7 +332,7 @@ func TestBlock(t *testing.T) {
 			[]*types.BlockIdentifier{newBlock.BlockIdentifier, newBlock2.BlockIdentifier},
 			txBlocks,
 		)
-		assert.Equal(t, int64(1), headDistance)
+		assert.Equal(t, int64(0), headDistance)
 	})
 
 	t.Run("Remove block and re-set block of same hash", func(t *testing.T) {
@@ -361,7 +361,7 @@ func TestBlock(t *testing.T) {
 			[]*types.BlockIdentifier{newBlock.BlockIdentifier, newBlock2.BlockIdentifier},
 			txBlocks,
 		)
-		assert.Equal(t, int64(1), headDistance)
+		assert.Equal(t, int64(0), headDistance)
 	})
 
 	t.Run("Add block with complex metadata", func(t *testing.T) {
@@ -375,6 +375,19 @@ func TestBlock(t *testing.T) {
 		head, err := storage.GetHeadBlockIdentifier(ctx)
 		assert.NoError(t, err)
 		assert.Equal(t, complexBlock.BlockIdentifier, head)
+
+		txBlocks, headDistance, err := storage.FindTransaction(
+			ctx,
+			newBlock.Transactions[0].TransactionIdentifier,
+		)
+		assert.NoError(t, err)
+		assert.Len(t, txBlocks, 2)
+		assert.ElementsMatch(
+			t,
+			[]*types.BlockIdentifier{newBlock.BlockIdentifier, newBlock2.BlockIdentifier},
+			txBlocks,
+		)
+		assert.Equal(t, int64(1), headDistance)
 	})
 
 	t.Run("Set duplicate transaction hash (same block)", func(t *testing.T) {

--- a/internal/storage/broadcast_storage.go
+++ b/internal/storage/broadcast_storage.go
@@ -34,20 +34,40 @@ type BroadcastStorage struct {
 	staleDepth        int64
 }
 
+// BroadcastStorageHelper is used by BroadcastStorage to submit transactions
+// and find said transaction in blocks on-chain.
 type BroadcastStorageHelper interface {
-	CurrentBlockIdentifier(context.Context) (*types.BlockIdentifier, error)             // used to determine if should rebroadcast
-	FindTransaction(context.Context, *types.TransactionIdentifier) (int64, error)       // used to confirm
+	// CurrentBlockIdentifier is called before transaction broadcast and is used
+	// to determine if a transaction broadcast is stale.
+	CurrentBlockIdentifier(context.Context) (*types.BlockIdentifier, error) // used to determine if should rebroadcast
+
+	// FindTransaction looks for the provided TransactionIdentifier in processed
+	// blocks and returns the depth since the most recent sighting.
+	FindTransaction(context.Context, *types.TransactionIdentifier) (*types.BlockIdentifier, int64, error) // used to confirm
+
+	// BroadcastTransaction broadcasts a transaction to a Rosetta implementation
+	// and returns the *types.TransactionIdentifier returned by the implementation.
 	BroadcastTransaction(context.Context, string) (*types.TransactionIdentifier, error) // handle initial broadcast + confirm matches provided + rebroadcast if stale
 }
 
+// BroadcastStorageHandler is invoked when a transaction is confirmed on-chain
+// or when a transaction is considered stale.
 type BroadcastStorageHandler interface {
-	TransactionConfirmed(context.Context, *types.Transaction, []*types.Operation) error // can use locked account again + confirm matches intent + update logger
-	TransactionRebroadcast(context.Context, *types.TransactionIdentifier) error         // log in counter
+	// TransactionConfirmed is called when a transaction is observed on-chain for the
+	// last time at a block height < current block height - confirmationDepth.
+	TransactionConfirmed(context.Context, *types.BlockIdentifier, *types.Transaction, []*types.Operation) error // can use locked account again + confirm matches intent + update logger
+
+	// TransactionStale is called when a transaction has not yet been
+	// seen on-chain and is considered stale. This occurs when
+	// current block height - last broadcast > staleDepth.
+	TransactionStale(context.Context, *types.TransactionIdentifier) error // log in counter (rebroadcast should occur here)
 }
 
-type Broadcast struct {
+// broadcast is persisted to the db to track transaction broadcast.
+type broadcast struct {
 	Identifier    *types.TransactionIdentifier `json:"identifier"`
 	Intent        []*types.Operation           `json:"intent"`
+	Payload       string                       `json:"payload"`
 	LastBroadcast *types.BlockIdentifier       `json:"broadcast_at"`
 }
 
@@ -64,6 +84,8 @@ func NewBroadcastStorage(
 	}
 }
 
+// Initialize adds a BroadcastStorageHelper and BroadcastStorageHandler to BroadcastStorage.
+// This must be called prior to syncing!
 func (b *BroadcastStorage) Initialize(helper BroadcastStorageHelper, handler BroadcastStorageHandler) {
 	b.helper = helper
 	b.handler = handler
@@ -89,9 +111,20 @@ func (b *BroadcastStorage) RemovingBlock(
 	return nil, nil
 }
 
-func (b *BroadcastStorage) Broadcast(ctx context.Context, transactionIdentifier *types.TransactionIdentifier) error {
+// Broadcast is called when a caller wants a transaction to be broadcast and tracked.
+// The caller SHOULD NOT broadcast the transaction before calling this function.
+func (b *BroadcastStorage) Broadcast(
+	ctx context.Context,
+	intent []*types.Operation,
+	transactionIdentifier *types.TransactionIdentifier,
+	payload string,
+) error {
 	return errors.New("not implemented")
 }
+
+// LockedAddresses returns all addresses currently broadcasting a transaction.
+// The caller SHOULD NOT broadcast a transaction from an account if it is
+// considered locked!
 func (b *BroadcastStorage) LockedAddresses() error {
 	return errors.New("not implemented")
 }

--- a/internal/storage/broadcast_storage.go
+++ b/internal/storage/broadcast_storage.go
@@ -1,0 +1,97 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"errors"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+var _ BlockWorker = (*BroadcastStorage)(nil)
+
+// BroadcastStorage implements storage methods for managing
+// transaction broadcast.
+type BroadcastStorage struct {
+	db      Database
+	helper  BroadcastStorageHelper
+	handler BroadcastStorageHandler
+
+	confirmationDepth int64
+	staleDepth        int64
+}
+
+type BroadcastStorageHelper interface {
+	CurrentBlockIdentifier(context.Context) (*types.BlockIdentifier, error)             // used to determine if should rebroadcast
+	FindTransaction(context.Context, *types.TransactionIdentifier) (int64, error)       // used to confirm
+	BroadcastTransaction(context.Context, string) (*types.TransactionIdentifier, error) // handle initial broadcast + confirm matches provided + rebroadcast if stale
+}
+
+type BroadcastStorageHandler interface {
+	TransactionConfirmed(context.Context, *types.Transaction, []*types.Operation) error // can use locked account again + confirm matches intent + update logger
+	TransactionRebroadcast(context.Context, *types.TransactionIdentifier) error         // log in counter
+}
+
+type Broadcast struct {
+	Identifier    *types.TransactionIdentifier `json:"identifier"`
+	Intent        []*types.Operation           `json:"intent"`
+	LastBroadcast *types.BlockIdentifier       `json:"broadcast_at"`
+}
+
+// NewBroadcastStorage returns a new BroadcastStorage.
+func NewBroadcastStorage(
+	db Database,
+	confirmationDepth int64,
+	staleDepth int64,
+) *BroadcastStorage {
+	return &BroadcastStorage{
+		db:                db,
+		confirmationDepth: confirmationDepth,
+		staleDepth:        staleDepth,
+	}
+}
+
+func (b *BroadcastStorage) Initialize(helper BroadcastStorageHelper, handler BroadcastStorageHandler) {
+	b.helper = helper
+	b.handler = handler
+}
+
+// AddingBlock is called by BlockStorage when adding a block.
+func (b *BroadcastStorage) AddingBlock(
+	ctx context.Context,
+	block *types.Block,
+	transaction DatabaseTransaction,
+) (CommitWorker, error) {
+	// TODO: call handler -> transactionRebroadcast should not block processing (could be in CommitWorker)
+	return nil, nil
+}
+
+// RemovingBlock is called by BlockStorage when removing a block.
+// TODO: error if transaction removed after confirmed (means confirmation depth not deep enough)
+func (b *BroadcastStorage) RemovingBlock(
+	ctx context.Context,
+	block *types.Block,
+	transaction DatabaseTransaction,
+) (CommitWorker, error) {
+	return nil, nil
+}
+
+func (b *BroadcastStorage) Broadcast(ctx context.Context, transactionIdentifier *types.TransactionIdentifier) error {
+	return errors.New("not implemented")
+}
+func (b *BroadcastStorage) LockedAddresses() error {
+	return errors.New("not implemented")
+}

--- a/internal/storage/broadcast_storage_test.go
+++ b/internal/storage/broadcast_storage_test.go
@@ -85,7 +85,13 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBroadcastStorage(database, confirmationDepth, staleDepth, broadcastLimit, broadcastTrailLimit)
+	storage := NewBroadcastStorage(
+		database,
+		confirmationDepth,
+		staleDepth,
+		broadcastLimit,
+		broadcastTrailLimit,
+	)
 	mockHelper := &MockBroadcastStorageHelper{}
 	mockHandler := &MockBroadcastStorageHandler{}
 	storage.Initialize(mockHelper, mockHandler)
@@ -93,12 +99,18 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 	send1 := opFiller("addr 1", 11)
 	send2 := opFiller("addr 2", 13)
 	mockHelper.Transactions = map[string]*types.TransactionIdentifier{
-		"payload 1": &types.TransactionIdentifier{Hash: "tx 1"},
-		"payload 2": &types.TransactionIdentifier{Hash: "tx 2"},
+		"payload 1": {Hash: "tx 1"},
+		"payload 2": {Hash: "tx 2"},
 	}
 
 	t.Run("broadcast send 1", func(t *testing.T) {
-		err := storage.Broadcast(ctx, "addr 1", send1, &types.TransactionIdentifier{Hash: "tx 1"}, "payload 1")
+		err := storage.Broadcast(
+			ctx,
+			"addr 1",
+			send1,
+			&types.TransactionIdentifier{Hash: "tx 1"},
+			"payload 1",
+		)
 		assert.NoError(t, err)
 
 		// Check to make sure duplicate instances of address aren't reported
@@ -157,7 +169,13 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 	})
 
 	t.Run("broadcast send 2", func(t *testing.T) {
-		err := storage.Broadcast(ctx, "addr 2", send2, &types.TransactionIdentifier{Hash: "tx 2"}, "payload 2")
+		err := storage.Broadcast(
+			ctx,
+			"addr 2",
+			send2,
+			&types.TransactionIdentifier{Hash: "tx 2"},
+			"payload 2",
+		)
 		assert.NoError(t, err)
 
 		// Check to make sure duplicate instances of address aren't reported
@@ -290,8 +308,14 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		block := blocks[3]
 		block.Transactions = []*types.Transaction{tx1, tx2}
 		mockHelper.FindTransactions = map[string]*findTx{
-			tx1.TransactionIdentifier.Hash: &findTx{blockIdentifier: block.BlockIdentifier, transaction: tx1},
-			tx2.TransactionIdentifier.Hash: &findTx{blockIdentifier: block.BlockIdentifier, transaction: tx2},
+			tx1.TransactionIdentifier.Hash: {
+				blockIdentifier: block.BlockIdentifier,
+				transaction:     tx1,
+			},
+			tx2.TransactionIdentifier.Hash: {
+				blockIdentifier: block.BlockIdentifier,
+				transaction:     tx2,
+			},
 		}
 		mockHelper.RemoteBlockIdentifier = block.BlockIdentifier
 
@@ -444,7 +468,13 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBroadcastStorage(database, confirmationDepth, staleDepth, broadcastLimit, broadcastTrailLimit)
+	storage := NewBroadcastStorage(
+		database,
+		confirmationDepth,
+		staleDepth,
+		broadcastLimit,
+		broadcastTrailLimit,
+	)
 	mockHelper := &MockBroadcastStorageHelper{}
 	mockHandler := &MockBroadcastStorageHandler{}
 	storage.Initialize(mockHelper, mockHandler)
@@ -459,10 +489,22 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 	send1 := opFiller("addr 1", 11)
 	send2 := opFiller("addr 2", 13)
 	t.Run("broadcast", func(t *testing.T) {
-		err := storage.Broadcast(ctx, "addr 1", send1, &types.TransactionIdentifier{Hash: "tx 1"}, "payload 1")
+		err := storage.Broadcast(
+			ctx,
+			"addr 1",
+			send1,
+			&types.TransactionIdentifier{Hash: "tx 1"},
+			"payload 1",
+		)
 		assert.NoError(t, err)
 
-		err = storage.Broadcast(ctx, "addr 2", send2, &types.TransactionIdentifier{Hash: "tx 2"}, "payload 2")
+		err = storage.Broadcast(
+			ctx,
+			"addr 2",
+			send2,
+			&types.TransactionIdentifier{Hash: "tx 2"},
+			"payload 2",
+		)
 		assert.NoError(t, err)
 
 		// Check to make sure duplicate instances of address aren't reported
@@ -491,7 +533,7 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 
 	t.Run("add blocks and expire", func(t *testing.T) {
 		mockHelper.Transactions = map[string]*types.TransactionIdentifier{
-			"payload 1": &types.TransactionIdentifier{Hash: "tx 1"},
+			"payload 1": {Hash: "tx 1"},
 			// payload 2 will fail
 		}
 		blocks := blockFiller(0, 10)
@@ -519,12 +561,12 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 		assert.ElementsMatch(t, []*Broadcast{}, broadcasts)
 
 		assert.ElementsMatch(t, []*types.TransactionIdentifier{
-			&types.TransactionIdentifier{Hash: "tx 1"},
-			&types.TransactionIdentifier{Hash: "tx 1"},
-			&types.TransactionIdentifier{Hash: "tx 1"},
-			&types.TransactionIdentifier{Hash: "tx 2"},
-			&types.TransactionIdentifier{Hash: "tx 2"},
-			&types.TransactionIdentifier{Hash: "tx 2"},
+			{Hash: "tx 1"},
+			{Hash: "tx 1"},
+			{Hash: "tx 1"},
+			{Hash: "tx 2"},
+			{Hash: "tx 2"},
+			{Hash: "tx 2"},
 		}, mockHandler.Stale)
 
 		assert.ElementsMatch(t, []*failedTx{
@@ -553,7 +595,13 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBroadcastStorage(database, confirmationDepth, staleDepth, broadcastLimit, broadcastTrailLimit)
+	storage := NewBroadcastStorage(
+		database,
+		confirmationDepth,
+		staleDepth,
+		broadcastLimit,
+		broadcastTrailLimit,
+	)
 	mockHelper := &MockBroadcastStorageHelper{}
 	mockHandler := &MockBroadcastStorageHandler{}
 	storage.Initialize(mockHelper, mockHandler)
@@ -561,10 +609,22 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 	send1 := opFiller("addr 1", 11)
 	send2 := opFiller("addr 2", 13)
 	t.Run("broadcast", func(t *testing.T) {
-		err := storage.Broadcast(ctx, "addr 1", send1, &types.TransactionIdentifier{Hash: "tx 1"}, "payload 1")
+		err := storage.Broadcast(
+			ctx,
+			"addr 1",
+			send1,
+			&types.TransactionIdentifier{Hash: "tx 1"},
+			"payload 1",
+		)
 		assert.NoError(t, err)
 
-		err = storage.Broadcast(ctx, "addr 2", send2, &types.TransactionIdentifier{Hash: "tx 2"}, "payload 2")
+		err = storage.Broadcast(
+			ctx,
+			"addr 2",
+			send2,
+			&types.TransactionIdentifier{Hash: "tx 2"},
+			"payload 2",
+		)
 		assert.NoError(t, err)
 
 		// Check to make sure duplicate instances of address aren't reported
@@ -594,8 +654,8 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 	blocks := blockFiller(0, 81)
 	mockHelper.RemoteBlockIdentifier = blocks[80].BlockIdentifier
 	mockHelper.Transactions = map[string]*types.TransactionIdentifier{
-		"payload 1": &types.TransactionIdentifier{Hash: "tx 1"},
-		"payload 2": &types.TransactionIdentifier{Hash: "tx 2"},
+		"payload 1": {Hash: "tx 1"},
+		"payload 2": {Hash: "tx 2"},
 	}
 
 	t.Run("add blocks behind tip", func(t *testing.T) {

--- a/internal/storage/broadcast_storage_test.go
+++ b/internal/storage/broadcast_storage_test.go
@@ -45,6 +45,13 @@ func TestBroadcastStorage(t *testing.T) {
 	mockHelper := &MockBroadcastStorageHelper{}
 	mockHandler := &MockBroadcastStorageHandler{}
 	storage.Initialize(mockHelper, mockHandler)
+
+	t.Run("locked addresses with no broadcasts", func(t *testing.T) {
+		addresses, err := storage.LockedAddresses(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, addresses, 0)
+		assert.NotNil(t, addresses)
+	})
 }
 
 var _ BroadcastStorageHelper = (*MockBroadcastStorageHelper)(nil)

--- a/internal/storage/broadcast_storage_test.go
+++ b/internal/storage/broadcast_storage_test.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/coinbase/rosetta-cli/internal/utils"
@@ -29,6 +30,20 @@ const (
 	staleDepth        = int64(1)
 	broadcastLimit    = 3
 )
+
+func makeFillerBlocks(start int64, end int64) []*types.Block {
+	blocks := []*types.Block{}
+	for i := start; i < end; i++ {
+		blocks = append(blocks, &types.Block{
+			BlockIdentifier: &types.BlockIdentifier{
+				Index: i,
+				Hash:  fmt.Sprintf("block %d", i),
+			},
+		})
+	}
+
+	return blocks
+}
 
 func TestBroadcastStorage(t *testing.T) {
 	ctx := context.Background()

--- a/internal/storage/broadcast_storage_test.go
+++ b/internal/storage/broadcast_storage_test.go
@@ -34,15 +34,42 @@ const (
 func makeFillerBlocks(start int64, end int64) []*types.Block {
 	blocks := []*types.Block{}
 	for i := start; i < end; i++ {
+		parentIndex := i - 1
+		if parentIndex < 0 {
+			parentIndex = 0
+		}
 		blocks = append(blocks, &types.Block{
 			BlockIdentifier: &types.BlockIdentifier{
 				Index: i,
 				Hash:  fmt.Sprintf("block %d", i),
 			},
+			ParentBlockIdentifier: &types.BlockIdentifier{
+				Index: parentIndex,
+				Hash:  fmt.Sprintf("block %d", parentIndex),
+			},
 		})
 	}
 
 	return blocks
+}
+
+func opFiller(sender string, opNumber int) []*types.Operation {
+	ops := make([]*types.Operation, opNumber)
+	for i := 0; i < opNumber; i++ {
+		ops[i] = &types.Operation{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(i),
+			},
+			Account: &types.AccountIdentifier{
+				Address: sender,
+				SubAccount: &types.SubAccountIdentifier{
+					Address: sender,
+				},
+			},
+		}
+	}
+
+	return ops
 }
 
 func TestBroadcastStorage(t *testing.T) {
@@ -66,6 +93,39 @@ func TestBroadcastStorage(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, addresses, 0)
 		assert.NotNil(t, addresses)
+	})
+
+	t.Run("broadcast", func(t *testing.T) {
+		send1 := opFiller("addr 1", 11)
+		err := storage.Broadcast(ctx, "addr 1", send1, &types.TransactionIdentifier{Hash: "tx 1"}, "payload 1")
+		assert.NoError(t, err)
+
+		send2 := opFiller("addr 2", 13)
+		err = storage.Broadcast(ctx, "addr 2", send2, &types.TransactionIdentifier{Hash: "tx 2"}, "payload 2")
+		assert.NoError(t, err)
+
+		// Check to make sure duplicate instances of address aren't reported
+		addresses, err := storage.LockedAddresses(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, addresses, 2)
+		assert.ElementsMatch(t, []string{"addr 1", "addr 2"}, addresses)
+
+		broadcasts, err := storage.GetAllBroadcasts(ctx)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []*Broadcast{
+			{
+				Identifier: &types.TransactionIdentifier{Hash: "tx 1"},
+				Sender:     "addr 1",
+				Intent:     send1,
+				Payload:    "payload 1",
+			},
+			{
+				Identifier: &types.TransactionIdentifier{Hash: "tx 2"},
+				Sender:     "addr 2",
+				Intent:     send2,
+				Payload:    "payload 2",
+			},
+		}, broadcasts)
 	})
 }
 

--- a/internal/storage/broadcast_storage_test.go
+++ b/internal/storage/broadcast_storage_test.go
@@ -1,0 +1,45 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+var _ BroadcastStorageHelper = (*MockBroadcastStorageHelper)(nil)
+
+type MockBroadcastStorageHelper struct{}
+
+func (m *MockBroadcastStorageHelper) CurrentBlockIdentifier(
+	ctx context.Context,
+) (*types.BlockIdentifier, error) {
+	return nil, nil
+}
+
+func (m *MockBroadcastStorageHelper) FindTransaction(
+	ctx context.Context,
+	transactionIdentifier *types.TransactionIdentifier,
+) (*types.BlockIdentifier, *types.Transaction, error) {
+	return nil, nil, nil
+}
+
+func (m *MockBroadcastStorageHelper) BroadcastTransaction(
+	ctx context.Context,
+	payload string,
+) (*types.TransactionIdentifier, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Related Issue: #68 

`BroadcastStorage` tracks the broadcast and confirmation of transactions on-chain. It contains the core broadcast logic used in automated construction API testing.

### Changes
- [x] Update `BlockStorage.FindTransaction` function signature based on learnings from `BroadcastStorage`
- [x] Add `BroadcastStorage` implementation
- [x] Add `BroadcastStorage` tests