### PR TITLE
Enhanced end condition

### DIFF
--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -138,7 +138,7 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 	})
 
 	g.Go(func() error {
-		return dataTester.WatchEndCondition(ctx, Config)
+		return dataTester.WatchEndConditions(ctx, Config)
 	})
 
 	sigListeners := []context.CancelFunc{cancel}

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -137,6 +137,10 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 		return dataTester.StartSyncing(ctx, StartIndex, EndIndex)
 	})
 
+	g.Go(func() error {
+		return dataTester.WatchEndCondition(ctx, Config)
+	})
+
 	sigListeners := []context.CancelFunc{cancel}
 	go handleSignals(sigListeners)
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -244,6 +244,12 @@ func DefaultConfiguration() *Configuration {
 	}
 }
 
+// EndCondition contains all condtions that check:data could end
+type EndCondition struct {
+	// End once the node has reached tip
+	EndAtTip bool `json:"end_at_tip"`
+}
+
 // DataConfiguration contains all configurations to run check:data.
 type DataConfiguration struct {
 	// ActiveReconciliationConcurrency is the concurrency to use while fetching accounts
@@ -311,6 +317,9 @@ type DataConfiguration struct {
 	// useful to just try to fetch all blocks before checking for balance
 	// consistency.
 	BalanceTrackingDisabled bool `json:"balance_tracking_disabled"`
+
+	// EndCondition defines the condition when the Data API would end
+	EndCondition EndCondition `json:"end_condition"`
 }
 
 // Configuration contains all configuration settings for running

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -249,7 +249,7 @@ type EndCondition struct {
 	// EndAtTip determines if syncer should stop once it reached the tip
 	EndAtTip bool `json:"end_at_tip"`
 
-	// EndDuration is an end condtion that dictates how long the
+	// EndDuration is an end condition that dictates how long the
 	// check:data command would be running for in seconds
 	EndDuration uint64 `json:"end_duration"`
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -323,7 +323,7 @@ type DataConfiguration struct {
 	BalanceTrackingDisabled bool `json:"balance_tracking_disabled"`
 
 	// EndCondition contains the conditions for the syncer to stop
-	EndConditions EndConditions `json:"end_conditions"`
+	EndConditions *EndConditions `json:"end_conditions,omitempty"`
 }
 
 // Configuration contains all configuration settings for running

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -317,7 +317,7 @@ type DataConfiguration struct {
 
 	// EndSeconds is an end condtion that dictates how long the
 	// check:data command would be running for
-	EndSeconds int64 `json:"end_seconds"`
+	EndSeconds uint64 `json:"end_seconds"`
 }
 
 // Configuration contains all configuration settings for running

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -312,7 +312,7 @@ type DataConfiguration struct {
 	// consistency.
 	BalanceTrackingDisabled bool `json:"balance_tracking_disabled"`
 
-	// EndAtTip is an end condition. syncing will stop once the node has reached tip,
+	// EndAtTip is an end condition. syncing will stop once tip is reached
 	EndAtTip bool `json:"end_at_tip"`
 
 	// EndDuration is an end condtion that dictates how long the

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -244,8 +244,8 @@ func DefaultConfiguration() *Configuration {
 	}
 }
 
-// EndCondition contains all the conditions for the syncer to stop.
-type EndCondition struct {
+// EndConditions contains all the conditions for the syncer to stop.
+type EndConditions struct {
 	// EndAtTip determines if syncer should stop once it reached the tip
 	EndAtTip bool `json:"end_at_tip"`
 
@@ -323,7 +323,7 @@ type DataConfiguration struct {
 	BalanceTrackingDisabled bool `json:"balance_tracking_disabled"`
 
 	// EndCondition contains the conditions for the syncer to stop
-	EndCondition EndCondition `json:"end_condition"`
+	EndConditions EndConditions `json:"end_conditions"`
 }
 
 // Configuration contains all configuration settings for running

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -250,8 +250,8 @@ type EndCondition struct {
 	EndAtTip bool `json:"end_at_tip"`
 
 	// EndDuration is an end condtion that dictates how long the
-	// check:data command would be running for
-	EndDuration string `json:"end_duration"`
+	// check:data command would be running for in seconds
+	EndDuration uint64 `json:"end_duration"`
 }
 
 // DataConfiguration contains all configurations to run check:data.

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -244,6 +244,16 @@ func DefaultConfiguration() *Configuration {
 	}
 }
 
+// EndCondition contains all the conditions for the syncer to stop.
+type EndCondition struct {
+	// EndAtTip determines if syncer should stop once it reached the tip
+	EndAtTip bool `json:"end_at_tip"`
+
+	// EndDuration is an end condtion that dictates how long the
+	// check:data command would be running for
+	EndDuration string `json:"end_duration"`
+}
+
 // DataConfiguration contains all configurations to run check:data.
 type DataConfiguration struct {
 	// ActiveReconciliationConcurrency is the concurrency to use while fetching accounts
@@ -312,12 +322,8 @@ type DataConfiguration struct {
 	// consistency.
 	BalanceTrackingDisabled bool `json:"balance_tracking_disabled"`
 
-	// EndAtTip is an end condition. syncing will stop once tip is reached
-	EndAtTip bool `json:"end_at_tip"`
-
-	// EndDuration is an end condtion that dictates how long the
-	// check:data command would be running for
-	EndDuration string `json:"end_duration"`
+	// EndCondition contains the conditions for the syncer to stop
+	EndCondition EndCondition `json:"end_condition"`
 }
 
 // Configuration contains all configuration settings for running

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -315,9 +315,9 @@ type DataConfiguration struct {
 	// EndAtTip is an end condition. syncing will stop once the node has reached tip,
 	EndAtTip bool `json:"end_at_tip"`
 
-	// EndSeconds is an end condtion that dictates how long the
+	// EndDuration is an end condtion that dictates how long the
 	// check:data command would be running for
-	EndSeconds uint64 `json:"end_seconds"`
+	EndDuration string `json:"end_duration"`
 }
 
 // Configuration contains all configuration settings for running

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -244,12 +244,6 @@ func DefaultConfiguration() *Configuration {
 	}
 }
 
-// EndCondition contains all condtions that check:data could end
-type EndCondition struct {
-	// End once the node has reached tip
-	EndAtTip bool `json:"end_at_tip"`
-}
-
 // DataConfiguration contains all configurations to run check:data.
 type DataConfiguration struct {
 	// ActiveReconciliationConcurrency is the concurrency to use while fetching accounts
@@ -318,8 +312,12 @@ type DataConfiguration struct {
 	// consistency.
 	BalanceTrackingDisabled bool `json:"balance_tracking_disabled"`
 
-	// EndCondition defines the condition when the Data API would end
-	EndCondition EndCondition `json:"end_condition"`
+	// EndAtTip is an end condition. syncing will stop once the node has reached tip,
+	EndAtTip bool `json:"end_at_tip"`
+
+	// EndSeconds is an end condtion that dictates how long the
+	// check:data command would be running for
+	EndSeconds int64 `json:"end_seconds"`
 }
 
 // Configuration contains all configuration settings for running

--- a/examples/configuration/default.json
+++ b/examples/configuration/default.json
@@ -82,7 +82,7 @@
   "reconciliation_disabled": false,
   "inactive_discrepency_search_disabled": false,
   "balance_tracking_disabled": false,
-  "end_condition": {
+  "end_conditions": {
     "end_at_tip": false,
     "end_duration": 0
   }

--- a/examples/configuration/default.json
+++ b/examples/configuration/default.json
@@ -81,6 +81,10 @@
   "interesting_accounts": "",
   "reconciliation_disabled": false,
   "inactive_discrepency_search_disabled": false,
-  "balance_tracking_disabled": false
+  "balance_tracking_disabled": false,
+  "end_condition": {
+    "end_at_tip": false,
+    "end_duration": 0
+  }
  }
 }

--- a/examples/configuration/simple.json
+++ b/examples/configuration/simple.json
@@ -14,7 +14,7 @@
   "reconciliation_disabled": true,
   "inactive_discrepency_search_disabled": true,
   "balance_tracking_disabled": true,
-  "end_condition": {
+  "end_conditions": {
     "end_at_tip": true,
     "end_duration": 7200
   }

--- a/examples/configuration/simple.json
+++ b/examples/configuration/simple.json
@@ -13,6 +13,10 @@
   "historical_balance_disabled": true,
   "reconciliation_disabled": true,
   "inactive_discrepency_search_disabled": true,
-  "balance_tracking_disabled": true 
+  "balance_tracking_disabled": true,
+  "end_condition": {
+    "end_at_tip": true,
+    "end_duration": 7200
+  }
  }
 }

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
-github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200806182127-a0b262f73fc3 h1:GSHZTufGuZ8nhS1pPQRSezrNu9s5vegqntoVsRX2Q3w=
-github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200806182127-a0b262f73fc3/go.mod h1:Q6dAY0kdG2X3jNaIYnkxnZOb8XEZQar9Q1RcnBgm/wQ=
 github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200807162047-31075a509b1f h1:U69ZwbTR10diY1MDi9LP/RxetVJzjd4bvIDUEs8XYvk=
 github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200807162047-31075a509b1f/go.mod h1:Q6dAY0kdG2X3jNaIYnkxnZOb8XEZQar9Q1RcnBgm/wQ=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/internal/statefulsyncer/stateful_syncer.go
+++ b/internal/statefulsyncer/stateful_syncer.go
@@ -230,7 +230,7 @@ func (s *StatefulSyncer) EndDurationLoop(
 
 		case <-t.C:
 			log.Printf(
-				"syncer has reached end condtion after %d seconds",
+				"syncer has reached end condition after %d seconds",
 				int(duration.Seconds()),
 			)
 			s.cancel()

--- a/internal/statefulsyncer/stateful_syncer.go
+++ b/internal/statefulsyncer/stateful_syncer.go
@@ -201,7 +201,7 @@ func (s *StatefulSyncer) EndAtTipLoop(
 			atTip, err := s.blockStorage.AtTip(ctx, tipDelay)
 			if err != nil {
 				log.Printf(
-					"%s: unable to evaluate if node is at tip\n",
+					"%s: unable to evaluate if node is at tip",
 					err.Error(),
 				)
 				continue
@@ -216,8 +216,8 @@ func (s *StatefulSyncer) EndAtTipLoop(
 	}
 }
 
-// EndSecondsLoop runs a loop that evaluates end condition EndSeconds
-func (s *StatefulSyncer) EndSecondsLoop(
+// EndDurationLoop runs a loop that evaluates end condition EndDuration
+func (s *StatefulSyncer) EndDurationLoop(
 	ctx context.Context,
 	duration time.Duration,
 ) {
@@ -231,7 +231,7 @@ func (s *StatefulSyncer) EndSecondsLoop(
 
 		case <-t.C:
 			log.Printf(
-				"StatefulSyncer has reached end condtion after %d seconds\n",
+				"StatefulSyncer has reached end condtion after %d seconds",
 				int(duration.Seconds()),
 			)
 			s.cancel()

--- a/internal/statefulsyncer/stateful_syncer.go
+++ b/internal/statefulsyncer/stateful_syncer.go
@@ -188,7 +188,6 @@ func (s *StatefulSyncer) EndAtTipLoop(
 	tipDelay int64,
 	interval time.Duration,
 ) {
-
 	tc := time.NewTicker(interval)
 	defer tc.Stop()
 

--- a/internal/statefulsyncer/stateful_syncer.go
+++ b/internal/statefulsyncer/stateful_syncer.go
@@ -200,14 +200,14 @@ func (s *StatefulSyncer) EndAtTipLoop(
 			atTip, err := s.blockStorage.AtTip(ctx, tipDelay)
 			if err != nil {
 				log.Printf(
-					"%s: unable to evaluate if node is at tip",
+					"%s: unable to evaluate if syncer is at tip",
 					err.Error(),
 				)
 				continue
 			}
 
 			if atTip {
-				log.Println("Node has reached tip")
+				log.Println("syncer has reached tip")
 				s.cancel()
 				return
 			}
@@ -230,7 +230,7 @@ func (s *StatefulSyncer) EndDurationLoop(
 
 		case <-t.C:
 			log.Printf(
-				"StatefulSyncer has reached end condtion after %d seconds",
+				"syncer has reached end condtion after %d seconds",
 				int(duration.Seconds()),
 			)
 			s.cancel()

--- a/internal/statefulsyncer/stateful_syncer.go
+++ b/internal/statefulsyncer/stateful_syncer.go
@@ -29,6 +29,14 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
+var (
+	// EndAtTipCheckInterval is the frequency that EndAtTip condition
+	// is evaludated
+	//
+	// TODO: make configurable
+	EndAtTipCheckInterval = 10 * time.Second
+)
+
 var _ syncer.Handler = (*StatefulSyncer)(nil)
 var _ syncer.Helper = (*StatefulSyncer)(nil)
 
@@ -186,9 +194,8 @@ func (s *StatefulSyncer) Block(
 func (s *StatefulSyncer) EndAtTipLoop(
 	ctx context.Context,
 	tipDelay int64,
-	interval time.Duration,
 ) {
-	tc := time.NewTicker(interval)
+	tc := time.NewTicker(EndAtTipCheckInterval)
 	defer tc.Stop()
 
 	for {

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -305,7 +305,7 @@ func (t *DataTester) WatchEndCondition(
 	config *configuration.Configuration,
 ) error {
 	if config.Data.EndAtTip {
-		// runs a go routine that ends when reach tip
+		// runs a go routine that ends when reaching tip
 		go t.syncer.EndAtTipLoop(ctx, config.TipDelay, EndAtTipCheckInterval)
 	}
 

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -298,19 +298,19 @@ func (t *DataTester) WatchEndConditions(
 	ctx context.Context,
 	config *configuration.Configuration,
 ) error {
-	endCond := config.Data.EndConditions
-	if endCond == nil {
+	endConds := config.Data.EndConditions
+	if endConds == nil {
 		return nil
 	}
 
-	if endCond.EndAtTip {
+	if endConds.EndAtTip {
 		// runs a go routine that ends when reaching tip
 		go t.syncer.EndAtTipLoop(ctx, config.TipDelay)
 	}
 
-	if endCond.EndDuration != 0 {
+	if endConds.EndDuration != 0 {
 		// runs a go routine that ends after a duration
-		go t.syncer.EndDurationLoop(ctx, time.Duration(endCond.EndDuration)*time.Second)
+		go t.syncer.EndDurationLoop(ctx, time.Duration(endConds.EndDuration)*time.Second)
 	}
 
 	return nil

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -300,7 +300,7 @@ func (t *DataTester) StartPeriodicLogger(
 }
 
 // WatchEndCondition starts go routines to watch the end conditions
-func (t *DataTester) WatchEndCondition(
+func (t *DataTester) WatchEndConditions(
 	ctx context.Context,
 	config *configuration.Configuration,
 ) error {

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -54,6 +54,12 @@ const (
 	//
 	// TODO: make configurable
 	PeriodicLoggingFrequency = 10 * time.Second
+
+	// EndAtTipCheckInterval is the frequency that EndAtTip condition
+	// is evaludated
+	//
+	// TODO: make configurable
+	EndAtTipCheckInterval = 10 * time.Second
 )
 
 // DataTester coordinates the `check:data` test.
@@ -300,7 +306,7 @@ func (t *DataTester) WatchEndCondition(
 ) error {
 	if config.Data.EndAtTip {
 		// runs a go routine that ends when reach tip
-		go t.syncer.EndAtTipLoop(ctx, config.TipDelay, 10*time.Second)
+		go t.syncer.EndAtTipLoop(ctx, config.TipDelay, EndAtTipCheckInterval)
 	}
 
 	if config.Data.EndDuration != "" {

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -54,12 +54,6 @@ const (
 	//
 	// TODO: make configurable
 	PeriodicLoggingFrequency = 10 * time.Second
-
-	// EndAtTipCheckInterval is the frequency that EndAtTip condition
-	// is evaludated
-	//
-	// TODO: make configurable
-	EndAtTipCheckInterval = 10 * time.Second
 )
 
 // DataTester coordinates the `check:data` test.
@@ -306,7 +300,7 @@ func (t *DataTester) WatchEndConditions(
 ) error {
 	if config.Data.EndConditions.EndAtTip {
 		// runs a go routine that ends when reaching tip
-		go t.syncer.EndAtTipLoop(ctx, config.TipDelay, EndAtTipCheckInterval)
+		go t.syncer.EndAtTipLoop(ctx, config.TipDelay)
 	}
 
 	if config.Data.EndConditions.EndDuration != 0 {

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -293,6 +293,19 @@ func (t *DataTester) StartPeriodicLogger(
 	return ctx.Err()
 }
 
+// WatchEndCondition starts go routines to watch the end conditions
+func (t *DataTester) WatchEndCondition(
+	ctx context.Context,
+	config *configuration.Configuration,
+) error {
+	if config.Data.EndCondition.EndAtTip {
+		// runs a go routine to end when reach tip
+		go t.syncer.EndAtTipLoop(ctx, config.TipDelay, 10*time.Second)
+	}
+
+	return nil
+}
+
 // HandleErr is called when `check:data` returns an error.
 // If historical balance lookups are enabled, HandleErr will attempt to
 // automatically find any missing balance-changing operations.

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -309,16 +309,9 @@ func (t *DataTester) WatchEndConditions(
 		go t.syncer.EndAtTipLoop(ctx, config.TipDelay, EndAtTipCheckInterval)
 	}
 
-	if config.Data.EndCondition.EndDuration != "" {
-		dur, err := time.ParseDuration(config.Data.EndCondition.EndDuration)
-		if err != nil {
-			log.Fatalf(
-				"%s: invalid during string for EndDuration",
-				err.Error(),
-			)
-		}
+	if config.Data.EndCondition.EndDuration != 0 {
 		// runs a go routine that ends after a duration
-		go t.syncer.EndDurationLoop(ctx, dur)
+		go t.syncer.EndDurationLoop(ctx, time.Duration(config.Data.EndCondition.EndDuration)*time.Second)
 	}
 
 	return nil

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -299,13 +299,20 @@ func (t *DataTester) WatchEndCondition(
 	config *configuration.Configuration,
 ) error {
 	if config.Data.EndAtTip {
-		// runs a go routine to end when reach tip
+		// runs a go routine that ends when reach tip
 		go t.syncer.EndAtTipLoop(ctx, config.TipDelay, 10*time.Second)
 	}
 
-	if config.Data.EndSeconds != 0 {
-		// runs a go routine to end after X second
-		go t.syncer.EndSecondsLoop(ctx, time.Duration(config.Data.EndSeconds)*time.Second)
+	if config.Data.EndDuration != "" {
+		dur, err := time.ParseDuration(config.Data.EndDuration)
+		if err != nil {
+			log.Fatalf(
+				"%s: invalid during string for EndDuration",
+				err.Error(),
+			)
+		}
+		// runs a go routine that ends after a duration
+		go t.syncer.EndDurationLoop(ctx, dur)
 	}
 
 	return nil

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -304,14 +304,14 @@ func (t *DataTester) WatchEndConditions(
 	ctx context.Context,
 	config *configuration.Configuration,
 ) error {
-	if config.Data.EndCondition.EndAtTip {
+	if config.Data.EndConditions.EndAtTip {
 		// runs a go routine that ends when reaching tip
 		go t.syncer.EndAtTipLoop(ctx, config.TipDelay, EndAtTipCheckInterval)
 	}
 
-	if config.Data.EndCondition.EndDuration != 0 {
+	if config.Data.EndConditions.EndDuration != 0 {
 		// runs a go routine that ends after a duration
-		go t.syncer.EndDurationLoop(ctx, time.Duration(config.Data.EndCondition.EndDuration)*time.Second)
+		go t.syncer.EndDurationLoop(ctx, time.Duration(config.Data.EndConditions.EndDuration)*time.Second)
 	}
 
 	return nil

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -298,9 +298,14 @@ func (t *DataTester) WatchEndCondition(
 	ctx context.Context,
 	config *configuration.Configuration,
 ) error {
-	if config.Data.EndCondition.EndAtTip {
+	if config.Data.EndAtTip {
 		// runs a go routine to end when reach tip
 		go t.syncer.EndAtTipLoop(ctx, config.TipDelay, 10*time.Second)
+	}
+
+	if config.Data.EndSeconds != 0 {
+		// runs a go routine to end after X second
+		go t.syncer.EndSecondsLoop(ctx, time.Duration(config.Data.EndSeconds)*time.Second)
 	}
 
 	return nil

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -299,18 +299,18 @@ func (t *DataTester) StartPeriodicLogger(
 	return ctx.Err()
 }
 
-// WatchEndCondition starts go routines to watch the end conditions
+// WatchEndConditions starts go routines to watch the end conditions
 func (t *DataTester) WatchEndConditions(
 	ctx context.Context,
 	config *configuration.Configuration,
 ) error {
-	if config.Data.EndAtTip {
+	if config.Data.EndCondition.EndAtTip {
 		// runs a go routine that ends when reaching tip
 		go t.syncer.EndAtTipLoop(ctx, config.TipDelay, EndAtTipCheckInterval)
 	}
 
-	if config.Data.EndDuration != "" {
-		dur, err := time.ParseDuration(config.Data.EndDuration)
+	if config.Data.EndCondition.EndDuration != "" {
+		dur, err := time.ParseDuration(config.Data.EndCondition.EndDuration)
 		if err != nil {
 			log.Fatalf(
 				"%s: invalid during string for EndDuration",

--- a/internal/tester/data.go
+++ b/internal/tester/data.go
@@ -298,14 +298,19 @@ func (t *DataTester) WatchEndConditions(
 	ctx context.Context,
 	config *configuration.Configuration,
 ) error {
-	if config.Data.EndConditions.EndAtTip {
+	endCond := config.Data.EndConditions
+	if endCond == nil {
+		return nil
+	}
+
+	if endCond.EndAtTip {
 		// runs a go routine that ends when reaching tip
 		go t.syncer.EndAtTipLoop(ctx, config.TipDelay)
 	}
 
-	if config.Data.EndConditions.EndDuration != 0 {
+	if endCond.EndDuration != 0 {
 		// runs a go routine that ends after a duration
-		go t.syncer.EndDurationLoop(ctx, time.Duration(config.Data.EndConditions.EndDuration)*time.Second)
+		go t.syncer.EndDurationLoop(ctx, time.Duration(endCond.EndDuration)*time.Second)
 	}
 
 	return nil


### PR DESCRIPTION
Closes: #66

Add end condition `end_at_tip` and `end_duration` for the `check:data` command. 
User can specify the end conditions under the `data/end_conditions` section of the configuration file. 

For example, to exit when `tip is reached` OR `after 3600 secs`:
```
"data": {
  "end_conditions": {
    "end_at_tip": true,
    "end_duration": 3600
  }
}
```
### Changes
- [x] Add end condition `end_at_tip` implementation
- [x] Add end condition `end_duration` implementation