### PR TITLE
Support Omitted Blocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200808203554-be8e8fc68ebe
+	github.com/coinbase/rosetta-sdk-go v0.3.4
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/dgraph-io/ristretto v0.0.2 // indirect
 	github.com/ethereum/go-ethereum v1.9.18

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200807162047-31075a509b1f
+	github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200808203554-be8e8fc68ebe
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/dgraph-io/ristretto v0.0.2 // indirect
 	github.com/ethereum/go-ethereum v1.9.18

--- a/go.sum
+++ b/go.sum
@@ -54,10 +54,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
-github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200807162047-31075a509b1f h1:U69ZwbTR10diY1MDi9LP/RxetVJzjd4bvIDUEs8XYvk=
-github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200807162047-31075a509b1f/go.mod h1:Q6dAY0kdG2X3jNaIYnkxnZOb8XEZQar9Q1RcnBgm/wQ=
-github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200808203554-be8e8fc68ebe h1:qFvooSvGBzzrhDi+KifU8b+hrLiw2ZjDOVREcABPBS8=
-github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200808203554-be8e8fc68ebe/go.mod h1:Q6dAY0kdG2X3jNaIYnkxnZOb8XEZQar9Q1RcnBgm/wQ=
+github.com/coinbase/rosetta-sdk-go v0.3.4 h1:jWKgajozco/T0FNnZb2TqBsmsUoF6ZuCLnUJkEE+vNg=
+github.com/coinbase/rosetta-sdk-go v0.3.4/go.mod h1:Q6dAY0kdG2X3jNaIYnkxnZOb8XEZQar9Q1RcnBgm/wQ=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200807162047-31075a509b1f h1:U69ZwbTR10diY1MDi9LP/RxetVJzjd4bvIDUEs8XYvk=
 github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200807162047-31075a509b1f/go.mod h1:Q6dAY0kdG2X3jNaIYnkxnZOb8XEZQar9Q1RcnBgm/wQ=
+github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200808203554-be8e8fc68ebe h1:qFvooSvGBzzrhDi+KifU8b+hrLiw2ZjDOVREcABPBS8=
+github.com/coinbase/rosetta-sdk-go v0.3.4-0.20200808203554-be8e8fc68ebe/go.mod h1:Q6dAY0kdG2X3jNaIYnkxnZOb8XEZQar9Q1RcnBgm/wQ=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/pkg/processor/reconciler_helper.go
+++ b/pkg/processor/reconciler_helper.go
@@ -49,7 +49,7 @@ func (h *ReconcilerHelper) BlockExists(
 	ctx context.Context,
 	block *types.BlockIdentifier,
 ) (bool, error) {
-	_, err := h.blockStorage.GetBlock(ctx, block)
+	_, err := h.blockStorage.GetBlock(ctx, types.ConstructPartialBlockIdentifier(block))
 	if err == nil {
 		return true, nil
 	}

--- a/pkg/storage/block_storage_test.go
+++ b/pkg/storage/block_storage_test.go
@@ -303,7 +303,15 @@ func TestBlock(t *testing.T) {
 		err := storage.AddBlock(ctx, newBlock)
 		assert.NoError(t, err)
 
-		block, err := storage.GetBlock(ctx, newBlock.BlockIdentifier)
+		block, err := storage.GetBlock(ctx, types.ConstructPartialBlockIdentifier(newBlock.BlockIdentifier))
+		assert.NoError(t, err)
+		assert.Equal(t, newBlock, block)
+
+		block, err = storage.GetBlock(ctx, &types.PartialBlockIdentifier{Index: &newBlock.BlockIdentifier.Index})
+		assert.NoError(t, err)
+		assert.Equal(t, newBlock, block)
+
+		block, err = storage.GetBlock(ctx, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, newBlock, block)
 
@@ -322,25 +330,46 @@ func TestBlock(t *testing.T) {
 	})
 
 	t.Run("Get non-existent block", func(t *testing.T) {
-		block, err := storage.GetBlock(ctx, badBlockIdentifier)
+		identifier := types.ConstructPartialBlockIdentifier(badBlockIdentifier)
+		block, err := storage.GetBlock(ctx, identifier)
 		assert.EqualError(
 			t,
 			err,
-			fmt.Errorf("%w %+v", ErrBlockNotFound, badBlockIdentifier).Error(),
+			fmt.Errorf("%w: %+v", ErrBlockNotFound, identifier).Error(),
+		)
+		assert.Nil(t, block)
+	})
+
+	t.Run("Get non-existent block index", func(t *testing.T) {
+		badIndex := int64(100000)
+		identifier := &types.PartialBlockIdentifier{Index: &badIndex}
+		block, err := storage.GetBlock(ctx, identifier)
+		assert.EqualError(
+			t,
+			err,
+			fmt.Errorf("%w: %+v", ErrBlockNotFound, identifier).Error(),
 		)
 		assert.Nil(t, block)
 	})
 
 	t.Run("Set duplicate block hash", func(t *testing.T) {
 		err = storage.AddBlock(ctx, newBlock)
-		assert.Contains(t, err.Error(), ErrDuplicateBlockHash.Error())
+		assert.Contains(t, err.Error(), ErrDuplicateKey.Error())
 	})
 
 	t.Run("Set duplicate transaction hash (from prior block)", func(t *testing.T) {
 		err = storage.AddBlock(ctx, newBlock2)
 		assert.NoError(t, err)
 
-		block, err := storage.GetBlock(ctx, newBlock2.BlockIdentifier)
+		block, err := storage.GetBlock(ctx, types.ConstructPartialBlockIdentifier(newBlock2.BlockIdentifier))
+		assert.NoError(t, err)
+		assert.Equal(t, newBlock2, block)
+
+		block, err = storage.GetBlock(ctx, &types.PartialBlockIdentifier{Index: &newBlock2.BlockIdentifier.Index})
+		assert.NoError(t, err)
+		assert.Equal(t, newBlock2, block)
+
+		block, err = storage.GetBlock(ctx, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, newBlock2, block)
 
@@ -387,7 +416,7 @@ func TestBlock(t *testing.T) {
 		err := storage.AddBlock(ctx, complexBlock)
 		assert.NoError(t, err)
 
-		block, err := storage.GetBlock(ctx, complexBlock.BlockIdentifier)
+		block, err := storage.GetBlock(ctx, types.ConstructPartialBlockIdentifier(complexBlock.BlockIdentifier))
 		assert.NoError(t, err)
 		assert.Equal(t, complexBlock, block)
 
@@ -418,7 +447,7 @@ func TestBlock(t *testing.T) {
 		err := storage.AddBlock(ctx, gapBlock)
 		assert.NoError(t, err)
 
-		block, err := storage.GetBlock(ctx, gapBlock.BlockIdentifier)
+		block, err := storage.GetBlock(ctx, types.ConstructPartialBlockIdentifier(gapBlock.BlockIdentifier))
 		assert.NoError(t, err)
 		assert.Equal(t, gapBlock, block)
 

--- a/pkg/storage/block_storage_test.go
+++ b/pkg/storage/block_storage_test.go
@@ -303,11 +303,17 @@ func TestBlock(t *testing.T) {
 		err := storage.AddBlock(ctx, newBlock)
 		assert.NoError(t, err)
 
-		block, err := storage.GetBlock(ctx, types.ConstructPartialBlockIdentifier(newBlock.BlockIdentifier))
+		block, err := storage.GetBlock(
+			ctx,
+			types.ConstructPartialBlockIdentifier(newBlock.BlockIdentifier),
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, newBlock, block)
 
-		block, err = storage.GetBlock(ctx, &types.PartialBlockIdentifier{Index: &newBlock.BlockIdentifier.Index})
+		block, err = storage.GetBlock(
+			ctx,
+			&types.PartialBlockIdentifier{Index: &newBlock.BlockIdentifier.Index},
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, newBlock, block)
 
@@ -361,11 +367,17 @@ func TestBlock(t *testing.T) {
 		err = storage.AddBlock(ctx, newBlock2)
 		assert.NoError(t, err)
 
-		block, err := storage.GetBlock(ctx, types.ConstructPartialBlockIdentifier(newBlock2.BlockIdentifier))
+		block, err := storage.GetBlock(
+			ctx,
+			types.ConstructPartialBlockIdentifier(newBlock2.BlockIdentifier),
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, newBlock2, block)
 
-		block, err = storage.GetBlock(ctx, &types.PartialBlockIdentifier{Index: &newBlock2.BlockIdentifier.Index})
+		block, err = storage.GetBlock(
+			ctx,
+			&types.PartialBlockIdentifier{Index: &newBlock2.BlockIdentifier.Index},
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, newBlock2, block)
 
@@ -416,7 +428,10 @@ func TestBlock(t *testing.T) {
 		err := storage.AddBlock(ctx, complexBlock)
 		assert.NoError(t, err)
 
-		block, err := storage.GetBlock(ctx, types.ConstructPartialBlockIdentifier(complexBlock.BlockIdentifier))
+		block, err := storage.GetBlock(
+			ctx,
+			types.ConstructPartialBlockIdentifier(complexBlock.BlockIdentifier),
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, complexBlock, block)
 
@@ -447,7 +462,10 @@ func TestBlock(t *testing.T) {
 		err := storage.AddBlock(ctx, gapBlock)
 		assert.NoError(t, err)
 
-		block, err := storage.GetBlock(ctx, types.ConstructPartialBlockIdentifier(gapBlock.BlockIdentifier))
+		block, err := storage.GetBlock(
+			ctx,
+			types.ConstructPartialBlockIdentifier(gapBlock.BlockIdentifier),
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, gapBlock, block)
 
@@ -455,7 +473,6 @@ func TestBlock(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, gapBlock.BlockIdentifier, head)
 	})
-
 }
 
 func TestCreateBlockCache(t *testing.T) {
@@ -508,7 +525,11 @@ func TestCreateBlockCache(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(
 			t,
-			[]*types.BlockIdentifier{genesisBlock.BlockIdentifier, newBlock.BlockIdentifier, simpleGap.BlockIdentifier},
+			[]*types.BlockIdentifier{
+				genesisBlock.BlockIdentifier,
+				newBlock.BlockIdentifier,
+				simpleGap.BlockIdentifier,
+			},
 			storage.CreateBlockCache(ctx),
 		)
 	})


### PR DESCRIPTION
Blocked by: https://github.com/coinbase/rosetta-sdk-go/pull/91

This PR adds support for storing omitted blocks and for querying blocks by only index or only hash (previously had to provide both block hash and index).

### Warning
This PR changes how data is persisted to storage. When you upgrade, you will need to delete any cache you were using previously.

### Changes
- [x] Update `syncer` to support omitted blocks (https://github.com/coinbase/rosetta-sdk-go/pull/91)
- [x] Add tests to storage for omitted blocks
- [x] Add lookup block by index