### PR TITLE
Prepare for reconciler end condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,7 @@ Usage:
   rosetta-cli check:data [flags]
 
 Flags:
-      --end int     block index to stop syncing (default -1)
-  -h, --help        help for check:data
-      --start int   block index to start syncing (default -1)
+  -h, --help   help for check:data
 
 Global Flags:
       --configuration-file string   Configuration file that provides connection and test settings.

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -67,28 +67,7 @@ bootstrap balance config. You can look at the examples folder for an example
 of what one of these files looks like.`,
 		Run: runCheckDataCmd,
 	}
-
-	// StartIndex is the block index to start syncing.
-	StartIndex int64
-
-	// EndIndex is the block index to stop syncing.
-	EndIndex int64
 )
-
-func init() {
-	checkDataCmd.Flags().Int64Var(
-		&StartIndex,
-		"start",
-		-1,
-		"block index to start syncing",
-	)
-	checkDataCmd.Flags().Int64Var(
-		&EndIndex,
-		"end",
-		-1,
-		"block index to stop syncing",
-	)
-}
 
 func runCheckDataCmd(cmd *cobra.Command, args []string) {
 	ensureDataDirectoryExists()
@@ -134,11 +113,11 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 	})
 
 	g.Go(func() error {
-		return dataTester.StartSyncing(ctx, StartIndex, EndIndex)
+		return dataTester.StartSyncing(ctx)
 	})
 
 	g.Go(func() error {
-		return dataTester.WatchEndConditions(ctx, Config)
+		return dataTester.WatchEndConditions(ctx)
 	})
 
 	sigListeners := []context.CancelFunc{cancel}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,6 +142,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.4.1")
+		fmt.Println("v0.4.2")
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,6 +142,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.4.2")
+		fmt.Println("v0.4.2-beta-101")
 	},
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -338,7 +338,7 @@ type DataConfiguration struct {
 	// StartIndex is the block height to start syncing from. If no StartIndex
 	// is provided, syncing will start from the last saved block.
 	// If no blocks have ever been synced, syncing will start from genesis.
-	StartIndex *int64 `json:"start_index"`
+	StartIndex *int64 `json:"start_index,omitempty"`
 
 	// EndCondition contains the conditions for the syncer to stop
 	EndConditions *DataEndConditions `json:"end_conditions,omitempty"`

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -26,7 +26,10 @@ import (
 )
 
 var (
-	whackyConfig = &Configuration{
+	startIndex    = int64(89)
+	badStartIndex = int64(-10)
+	endTip        = false
+	whackyConfig  = &Configuration{
 		Network: &types.NetworkIdentifier{
 			Blockchain: "sweet",
 			Network:    "sweeter",
@@ -61,6 +64,7 @@ var (
 			InactiveReconciliationFrequency:   3,
 			ReconciliationDisabled:            true,
 			HistoricalBalanceDisabled:         true,
+			StartIndex:                        &startIndex,
 		},
 	}
 	invalidNetwork = &Configuration{
@@ -93,6 +97,26 @@ var (
 	invalidMaximumFee = &Configuration{
 		Construction: &ConstructionConfiguration{
 			MaximumFee: "hello",
+		},
+	}
+	invalidStartIndex = &Configuration{
+		Data: &DataConfiguration{
+			StartIndex: &badStartIndex,
+		},
+	}
+	multipleEndConditions = &Configuration{
+		Data: &DataConfiguration{
+			EndConditions: &DataEndConditions{
+				Index: &startIndex,
+				Tip:   &endTip,
+			},
+		},
+	}
+	invalidEndIndex = &Configuration{
+		Data: &DataConfiguration{
+			EndConditions: &DataEndConditions{
+				Index: &badStartIndex,
+			},
 		},
 	}
 )
@@ -141,6 +165,18 @@ func TestLoadConfiguration(t *testing.T) {
 		},
 		"invalid maximum fee": {
 			provided: invalidMaximumFee,
+			err:      true,
+		},
+		"invalid start index": {
+			provided: invalidStartIndex,
+			err:      true,
+		},
+		"invalid end index": {
+			provided: invalidEndIndex,
+			err:      true,
+		},
+		"multiple end conditions": {
+			provided: multipleEndConditions,
 			err:      true,
 		},
 	}

--- a/examples/configuration/default.json
+++ b/examples/configuration/default.json
@@ -9,6 +9,8 @@
  "sync_concurrency": 8,
  "transaction_concurrency": 16,
  "tip_delay": 300,
+ "disable_memory_limit": false,
+ "log_configuration": false,
  "construction": {
   "offline_url": "http://localhost:8080",
   "currency": {
@@ -82,9 +84,6 @@
   "reconciliation_disabled": false,
   "inactive_discrepency_search_disabled": false,
   "balance_tracking_disabled": false,
-  "end_conditions": {
-    "end_at_tip": false,
-    "end_duration": 0
-  }
+  "coin_tracking_disabled": false
  }
 }

--- a/examples/configuration/simple.json
+++ b/examples/configuration/simple.json
@@ -15,8 +15,7 @@
   "inactive_discrepency_search_disabled": true,
   "balance_tracking_disabled": true,
   "end_conditions": {
-    "end_at_tip": true,
-    "end_duration": 7200
+    "tip": true
   }
  }
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.3.4
+	github.com/coinbase/rosetta-sdk-go v0.3.5-0.20200811183334-1f5941596298
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/dgraph-io/ristretto v0.0.2 // indirect
 	github.com/ethereum/go-ethereum v1.9.18

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/coinbase/rosetta-sdk-go v0.3.4 h1:jWKgajozco/T0FNnZb2TqBsmsUoF6ZuCLnUJkEE+vNg=
 github.com/coinbase/rosetta-sdk-go v0.3.4/go.mod h1:Q6dAY0kdG2X3jNaIYnkxnZOb8XEZQar9Q1RcnBgm/wQ=
+github.com/coinbase/rosetta-sdk-go v0.3.5-0.20200811183334-1f5941596298 h1:5HCZjZyLTDZ1XF7tSUV4t1PqnSPQenkj0bVlpYYCr1U=
+github.com/coinbase/rosetta-sdk-go v0.3.5-0.20200811183334-1f5941596298/go.mod h1:Q6dAY0kdG2X3jNaIYnkxnZOb8XEZQar9Q1RcnBgm/wQ=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/pkg/processor/balance_storage_helper.go
+++ b/pkg/processor/balance_storage_helper.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/coinbase/rosetta-cli/pkg/storage"
+	"github.com/coinbase/rosetta-cli/pkg/utils"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
@@ -90,20 +91,20 @@ func (h *BalanceStorageHelper) AccountBalance(
 	// In the case that we are syncing from arbitrary height,
 	// we may need to recover the balance of an account to
 	// perform validations.
-	_, value, err := reconciler.GetCurrencyBalance(
+	amount, _, err := utils.CurrencyBalance(
 		ctx,
-		h.fetcher,
 		h.network,
+		h.fetcher,
 		account,
 		currency,
-		types.ConstructPartialBlockIdentifier(block),
+		block,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: unable to get currency balance in storage helper", err)
+		return nil, fmt.Errorf("%w: unable to get currency balance", err)
 	}
 
 	return &types.Amount{
-		Value:    value,
+		Value:    amount.Value,
 		Currency: currency,
 	}, nil
 }

--- a/pkg/statefulsyncer/stateful_syncer.go
+++ b/pkg/statefulsyncer/stateful_syncer.go
@@ -17,9 +17,7 @@ package statefulsyncer
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/big"
-	"time"
 
 	"github.com/coinbase/rosetta-cli/pkg/logger"
 	"github.com/coinbase/rosetta-cli/pkg/storage"
@@ -27,14 +25,6 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/syncer"
 	"github.com/coinbase/rosetta-sdk-go/types"
-)
-
-var (
-	// EndAtTipCheckInterval is the frequency that EndAtTip condition
-	// is evaludated
-	//
-	// TODO: make configurable
-	EndAtTipCheckInterval = 10 * time.Second
 )
 
 var _ syncer.Handler = (*StatefulSyncer)(nil)
@@ -188,60 +178,4 @@ func (s *StatefulSyncer) Block(
 	block *types.PartialBlockIdentifier,
 ) (*types.Block, error) {
 	return s.fetcher.BlockRetry(ctx, network, block)
-}
-
-// EndAtTipLoop runs a loop that evaluates end condition EndAtTip
-func (s *StatefulSyncer) EndAtTipLoop(
-	ctx context.Context,
-	tipDelay int64,
-) {
-	tc := time.NewTicker(EndAtTipCheckInterval)
-	defer tc.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-
-		case <-tc.C:
-			atTip, err := s.blockStorage.AtTip(ctx, tipDelay)
-			if err != nil {
-				log.Printf(
-					"%s: unable to evaluate if syncer is at tip",
-					err.Error(),
-				)
-				continue
-			}
-
-			if atTip {
-				log.Println("syncer has reached tip")
-				s.cancel()
-				return
-			}
-		}
-	}
-}
-
-// EndDurationLoop runs a loop that evaluates end condition EndDuration
-func (s *StatefulSyncer) EndDurationLoop(
-	ctx context.Context,
-	duration time.Duration,
-) {
-	t := time.NewTimer(duration)
-	defer t.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-
-		case <-t.C:
-			log.Printf(
-				"syncer has reached end condition after %d seconds",
-				int(duration.Seconds()),
-			)
-			s.cancel()
-			return
-		}
-	}
 }

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -165,6 +165,8 @@ func InitializeData(
 	)
 
 	reconcilerHelper := processor.NewReconcilerHelper(
+		network,
+		fetcher,
 		blockStorage,
 		balanceStorage,
 	)
@@ -181,10 +183,8 @@ func InitializeData(
 	}
 
 	r := reconciler.New(
-		network,
 		reconcilerHelper,
 		reconcilerHandler,
-		fetcher,
 		reconciler.WithActiveConcurrency(int(config.Data.ActiveReconciliationConcurrency)),
 		reconciler.WithInactiveConcurrency(int(config.Data.InactiveReconciliationConcurrency)),
 		reconciler.WithLookupBalanceByBlock(!config.Data.HistoricalBalanceDisabled),
@@ -507,6 +507,8 @@ func (t *DataTester) recursiveOpSearch(
 	)
 
 	reconcilerHelper := processor.NewReconcilerHelper(
+		t.network,
+		t.fetcher,
 		blockStorage,
 		balanceStorage,
 	)
@@ -517,10 +519,8 @@ func (t *DataTester) recursiveOpSearch(
 	)
 
 	r := reconciler.New(
-		t.network,
 		reconcilerHelper,
 		reconcilerHandler,
-		t.fetcher,
 
 		// When using concurrency > 1, we could start looking up balance changes
 		// on multiple blocks at once. This can cause us to return the wrong block


### PR DESCRIPTION
This PR performs some small refactors in preparation for adding a new `reconciler` end condition (i.e. end `check:data` after some % of accounts reconciled at tip). 

### Changes
- [x] Move `start` and `end` to configuration file
- [x] Refactor end conditions check to `tester`
- [x] Assert that only 1 end index is populated at a time
- [x] Update rosetta-sdk-go package (https://github.com/coinbase/rosetta-sdk-go/pull/92)