### PR TITLE
Reconciler End Condition

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,6 +142,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.4.2-beta-101")
+		fmt.Println("v0.4.2-beta-102")
 	},
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -582,15 +582,21 @@ func assertDataConfiguration(config *DataConfiguration) error {
 		}
 
 		if config.BalanceTrackingDisabled {
-			return errors.New("balance tracking must be enabled for reconciliation coverage end condition")
+			return errors.New(
+				"balance tracking must be enabled for reconciliation coverage end condition",
+			)
 		}
 
 		if config.IgnoreReconciliationError {
-			return errors.New("reconciliation errors cannot be ignored for reconciliation coverage end condition")
+			return errors.New(
+				"reconciliation errors cannot be ignored for reconciliation coverage end condition",
+			)
 		}
 
 		if config.ReconciliationDisabled {
-			return errors.New("reconciliation cannot be disabled for reconciliation coverage end condition")
+			return errors.New(
+				"reconciliation cannot be disabled for reconciliation coverage end condition",
+			)
 		}
 	}
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -577,7 +577,7 @@ func assertDataConfiguration(config *DataConfiguration) error {
 		foundConditions++
 		coverage := *config.EndConditions.ReconciliationCoverage
 		if coverage < 0 || coverage > 1 {
-			return fmt.Errorf("reconcilation coverage %f must be [0.0,1.0]", coverage)
+			return fmt.Errorf("reconciliation coverage %f must be [0.0,1.0]", coverage)
 		}
 	}
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -67,6 +67,22 @@ const (
 	EthereumMaximumFee      = "5000000000000000" // 0.005 ETH
 	EthereumCurveType       = types.Secp256k1
 	EthereumAccountingModel = AccountModel
+
+	// IndexEndCondition is used to indicate that the index end condition
+	// has been met.
+	IndexEndCondition = "Index End Condition"
+
+	// DurationEndCondition is used to indicate that the duration
+	// end condition has been met.
+	DurationEndCondition = "Duration End Condition"
+
+	// TipEndCondition is used to indicate that the tip end condition
+	// has been met.
+	TipEndCondition = "Tip End Condition"
+
+	// ReconciliationCoverageEndCondition is used to indicate that the reconciliation
+	// coverage end condition has been met.
+	ReconciliationCoverageEndCondition = "Reconciliation Coverage End Condition"
 )
 
 // Default Configuration Values

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -259,6 +259,13 @@ type DataEndConditions struct {
 	// Duration configures the syncer to stop after running
 	// for Duration seconds.
 	Duration *uint64 `json:"duration,omitempty"`
+
+	// ReconciliationCoverage configures the syncer to stop
+	// once it has reached tip AND some proportion of
+	// all addresses have been reconciled at an index >=
+	// to when tip was first reached. The range of inputs
+	// for this condition are [0.0, 1.0].
+	ReconciliationCoverage *float64 `json:"reconciliation_coverage,omitempty"`
 }
 
 // DataConfiguration contains all configurations to run check:data.
@@ -564,6 +571,14 @@ func assertDataConfiguration(config *DataConfiguration) error {
 
 	if config.EndConditions.Duration != nil {
 		foundConditions++
+	}
+
+	if config.EndConditions.ReconciliationCoverage != nil {
+		foundConditions++
+		coverage := *config.EndConditions.ReconciliationCoverage
+		if coverage < 0 || coverage > 1 {
+			return fmt.Errorf("reconcilation coverage %f must be [0.0,1.0]", coverage)
+		}
 	}
 
 	if foundConditions != 1 {

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -15,6 +15,7 @@
 package configuration
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"math/big"
@@ -578,6 +579,18 @@ func assertDataConfiguration(config *DataConfiguration) error {
 		coverage := *config.EndConditions.ReconciliationCoverage
 		if coverage < 0 || coverage > 1 {
 			return fmt.Errorf("reconciliation coverage %f must be [0.0,1.0]", coverage)
+		}
+
+		if config.BalanceTrackingDisabled {
+			return errors.New("balance tracking must be enabled for reconciliation coverage end condition")
+		}
+
+		if config.IgnoreReconciliationError {
+			return errors.New("reconciliation errors cannot be ignored for reconciliation coverage end condition")
+		}
+
+		if config.ReconciliationDisabled {
+			return errors.New("reconciliation cannot be disabled for reconciliation coverage end condition")
 		}
 	}
 

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -28,6 +28,8 @@ import (
 var (
 	startIndex    = int64(89)
 	badStartIndex = int64(-10)
+	goodCoverage  = float64(0.33)
+	badCoverage   = float64(-2)
 	endTip        = false
 	whackyConfig  = &Configuration{
 		Network: &types.NetworkIdentifier{
@@ -65,6 +67,9 @@ var (
 			ReconciliationDisabled:            true,
 			HistoricalBalanceDisabled:         true,
 			StartIndex:                        &startIndex,
+			EndConditions: &DataEndConditions{
+				ReconciliationCoverage: &goodCoverage,
+			},
 		},
 	}
 	invalidNetwork = &Configuration{
@@ -116,6 +121,13 @@ var (
 		Data: &DataConfiguration{
 			EndConditions: &DataEndConditions{
 				Index: &badStartIndex,
+			},
+		},
+	}
+	invalidReconciliationCoverage = &Configuration{
+		Data: &DataConfiguration{
+			EndConditions: &DataEndConditions{
+				ReconciliationCoverage: &badCoverage,
 			},
 		},
 	}
@@ -173,6 +185,10 @@ func TestLoadConfiguration(t *testing.T) {
 		},
 		"invalid end index": {
 			provided: invalidEndIndex,
+			err:      true,
+		},
+		"invalid reconciliation coverage": {
+			provided: invalidReconciliationCoverage,
 			err:      true,
 		},
 		"multiple end conditions": {

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -64,7 +64,7 @@ var (
 			ActiveReconciliationConcurrency:   100,
 			InactiveReconciliationConcurrency: 2938,
 			InactiveReconciliationFrequency:   3,
-			ReconciliationDisabled:            true,
+			ReconciliationDisabled:            false,
 			HistoricalBalanceDisabled:         true,
 			StartIndex:                        &startIndex,
 			EndConditions: &DataEndConditions{
@@ -190,6 +190,39 @@ func TestLoadConfiguration(t *testing.T) {
 		"invalid reconciliation coverage": {
 			provided: invalidReconciliationCoverage,
 			err:      true,
+		},
+		"invalid reconciliation coverage (reconciliation disabled)": {
+			provided: &Configuration{
+				Data: &DataConfiguration{
+					ReconciliationDisabled: true,
+					EndConditions: &DataEndConditions{
+						ReconciliationCoverage: &goodCoverage,
+					},
+				},
+			},
+			err: true,
+		},
+		"invalid reconciliation coverage (balance tracking disabled)": {
+			provided: &Configuration{
+				Data: &DataConfiguration{
+					BalanceTrackingDisabled: true,
+					EndConditions: &DataEndConditions{
+						ReconciliationCoverage: &goodCoverage,
+					},
+				},
+			},
+			err: true,
+		},
+		"invalid reconciliation coverage (ignore reconciliation error)": {
+			provided: &Configuration{
+				Data: &DataConfiguration{
+					IgnoreReconciliationError: true,
+					EndConditions: &DataEndConditions{
+						ReconciliationCoverage: &goodCoverage,
+					},
+				},
+			},
+			err: true,
 		},
 		"multiple end conditions": {
 			provided: multipleEndConditions,

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -146,10 +146,11 @@ func (l *Logger) LogDataStats(ctx context.Context) error {
 		}
 
 		statsMessage = fmt.Sprintf(
-			"Reconciliations (Coverage: %f%%): %s (Inactive: %s)",
-			coverage*utils.OneHundred,
+			"%s Reconciliations: %s (Inactive: %s, Coverage: %f%%)",
+			statsMessage,
 			new(big.Int).Add(activeReconciliations, inactiveReconciliations).String(),
 			inactiveReconciliations.String(),
+			coverage*utils.OneHundred,
 		)
 	}
 

--- a/pkg/processor/broadcast_storage_helper.go
+++ b/pkg/processor/broadcast_storage_helper.go
@@ -52,7 +52,7 @@ func (h *BroadcastStorageHelper) AtTip(
 	ctx context.Context,
 	tipDelay int64,
 ) (bool, error) {
-	atTip, err := h.blockStorage.AtTip(ctx, tipDelay)
+	atTip, _, err := h.blockStorage.AtTip(ctx, tipDelay)
 	if err != nil {
 		return false, fmt.Errorf("%w: unable to determine if at tip", err)
 	}

--- a/pkg/storage/balance_storage.go
+++ b/pkg/storage/balance_storage.go
@@ -239,7 +239,10 @@ func (b *BalanceStorage) Reconciled(
 
 // ReconciliationCoverage returns the proportion of accounts [0.0, 1.0] that
 // have been reconciled at an index >= to a minimumIndex.
-func (b *BalanceStorage) ReconciliationCoverage(ctx context.Context, minimumIndex int64) (float64, error) {
+func (b *BalanceStorage) ReconciliationCoverage(
+	ctx context.Context,
+	minimumIndex int64,
+) (float64, error) {
 	balances, err := b.getAllBalanceEntries(ctx)
 	if err != nil {
 		return -1, fmt.Errorf("%w: unable to get all balance entries", err)

--- a/pkg/storage/balance_storage.go
+++ b/pkg/storage/balance_storage.go
@@ -150,9 +150,10 @@ func (b *BalanceStorage) RemovingBlock(
 }
 
 type balanceEntry struct {
-	Account *types.AccountIdentifier `json:"account"`
-	Amount  *types.Amount            `json:"amount"`
-	Block   *types.BlockIdentifier   `json:"block"`
+	Account        *types.AccountIdentifier `json:"account"`
+	Amount         *types.Amount            `json:"amount"`
+	Block          *types.BlockIdentifier   `json:"block"`
+	LastReconciled *types.BlockIdentifier   `json:"last_reconciled"`
 }
 
 // SetBalance allows a client to set the balance of an account in a database
@@ -180,6 +181,86 @@ func (b *BalanceStorage) SetBalance(
 	}
 
 	return nil
+}
+
+// Reconciled updates the LastReconciled field on a particular
+// balance. Tracking reconciliation coverage is an important
+// end condition.
+func (b *BalanceStorage) Reconciled(
+	ctx context.Context,
+	account *types.AccountIdentifier,
+	currency *types.Currency,
+	block *types.BlockIdentifier,
+) error {
+	dbTransaction := b.db.NewDatabaseTransaction(ctx, true)
+	defer dbTransaction.Discard(ctx)
+
+	key := GetBalanceKey(account, currency)
+	exists, balance, err := dbTransaction.Get(ctx, key)
+	if err != nil {
+		return fmt.Errorf(
+			"%w: unable to get balance entry for account %s:%s",
+			err,
+			types.PrettyPrintStruct(account),
+			types.PrettyPrintStruct(currency),
+		)
+	}
+
+	if !exists {
+		return fmt.Errorf(
+			"balance entry is missing for account %s:%s",
+			types.PrettyPrintStruct(account),
+			types.PrettyPrintStruct(currency),
+		)
+	}
+
+	var bal balanceEntry
+	if err := decode(balance, &bal); err != nil {
+		return fmt.Errorf("%w: unable to decode balance entry", err)
+	}
+
+	bal.LastReconciled = block
+
+	serialBal, err := encode(bal)
+	if err != nil {
+		return fmt.Errorf("%w: unable to encod balance entry", err)
+	}
+
+	if err := dbTransaction.Set(ctx, key, serialBal); err != nil {
+		return fmt.Errorf("%w: unable to set balance entry", err)
+	}
+
+	if err := dbTransaction.Commit(ctx); err != nil {
+		return fmt.Errorf("%w: unable to commit last reconciliation update", err)
+	}
+
+	return nil
+}
+
+// ReconciliationCoverage returns the proportion of accounts [0.0, 1.0] that
+// have been reconciled at an index >= to a minimumIndex.
+func (b *BalanceStorage) ReconciliationCoverage(ctx context.Context, minimumIndex int64) (float64, error) {
+	balances, err := b.getAllBalanceEntries(ctx)
+	if err != nil {
+		return -1, fmt.Errorf("%w: unable to get all balance entries", err)
+	}
+
+	if len(balances) == 0 {
+		return 0, nil
+	}
+
+	validCoverage := 0
+	for _, b := range balances {
+		if b.LastReconciled == nil {
+			continue
+		}
+
+		if b.LastReconciled.Index >= minimumIndex {
+			validCoverage++
+		}
+	}
+
+	return float64(validCoverage) / float64(len(balances)), nil
 }
 
 // UpdateBalance updates a types.AccountIdentifer
@@ -324,7 +405,6 @@ func (b *BalanceStorage) GetBalance(
 // BootstrapBalance represents a balance of
 // a *types.AccountIdentifier and a *types.Currency in the
 // genesis block.
-// TODO: Must be exported for use
 type BootstrapBalance struct {
 	Account  *types.AccountIdentifier `json:"account_identifier,omitempty"`
 	Currency *types.Currency          `json:"currency,omitempty"`
@@ -392,32 +472,46 @@ func (b *BalanceStorage) BootstrapBalances(
 	return nil
 }
 
+func (b *BalanceStorage) getAllBalanceEntries(ctx context.Context) ([]*balanceEntry, error) {
+	rawBalances, err := b.db.Scan(ctx, []byte(balanceNamespace))
+	if err != nil {
+		return nil, fmt.Errorf("%w: database scan failed", err)
+	}
+
+	balances := make([]*balanceEntry, len(rawBalances))
+	for i, rawBalance := range rawBalances {
+		var deserialBal balanceEntry
+		err := decode(rawBalance, &deserialBal)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"%w: unable to parse balance entry for %s",
+				err,
+				string(rawBalance),
+			)
+		}
+
+		balances[i] = &deserialBal
+	}
+
+	return balances, nil
+}
+
 // GetAllAccountCurrency scans the db for all balances and returns a slice
 // of reconciler.AccountCurrency. This is useful for bootstrapping the reconciler
 // after restart.
 func (b *BalanceStorage) GetAllAccountCurrency(
 	ctx context.Context,
 ) ([]*reconciler.AccountCurrency, error) {
-	rawBalances, err := b.db.Scan(ctx, []byte(balanceNamespace))
+	balances, err := b.getAllBalanceEntries(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("%w database scan failed", err)
+		return nil, fmt.Errorf("%w: unable to get all balance entries", err)
 	}
 
-	accounts := make([]*reconciler.AccountCurrency, len(rawBalances))
-	for i, rawBalance := range rawBalances {
-		var deserialBal balanceEntry
-		err := decode(rawBalance, &deserialBal)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"%w unable to parse balance entry for %s",
-				err,
-				string(rawBalance),
-			)
-		}
-
+	accounts := make([]*reconciler.AccountCurrency, len(balances))
+	for i, balance := range balances {
 		accounts[i] = &reconciler.AccountCurrency{
-			Account:  deserialBal.Account,
-			Currency: deserialBal.Amount.Currency,
+			Account:  balance.Account,
+			Currency: balance.Amount.Currency,
 		}
 	}
 

--- a/pkg/storage/block_storage.go
+++ b/pkg/storage/block_storage.go
@@ -598,21 +598,21 @@ func (b *BlockStorage) FindTransaction(
 func (b *BlockStorage) AtTip(
 	ctx context.Context,
 	tipDelay int64,
-) (bool, error) {
+) (bool, *types.BlockIdentifier, error) {
 	block, err := b.GetBlock(ctx, nil)
 	if errors.Is(err, ErrHeadBlockNotFound) {
-		return false, nil
+		return false, nil, nil
 	}
 
 	if err != nil {
-		return false, fmt.Errorf("%w: unable to get head block", err)
+		return false, nil, fmt.Errorf("%w: unable to get head block", err)
 	}
 
 	currentTime := utils.Milliseconds()
 	tipCutoff := currentTime - (tipDelay * utils.MillisecondsInSecond)
 	if block.Timestamp < tipCutoff {
-		return false, nil
+		return false, nil, nil
 	}
 
-	return true, nil
+	return true, block.BlockIdentifier, nil
 }

--- a/pkg/storage/block_storage_test.go
+++ b/pkg/storage/block_storage_test.go
@@ -550,9 +550,10 @@ func TestAtTip(t *testing.T) {
 	tipDelay := int64(100)
 
 	t.Run("no blocks processed", func(t *testing.T) {
-		atTip, err := storage.AtTip(ctx, tipDelay)
+		atTip, blockIdentifier, err := storage.AtTip(ctx, tipDelay)
 		assert.NoError(t, err)
 		assert.False(t, atTip)
+		assert.Nil(t, blockIdentifier)
 	})
 
 	t.Run("Add old block", func(t *testing.T) {
@@ -569,9 +570,10 @@ func TestAtTip(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		atTip, err := storage.AtTip(ctx, tipDelay)
+		atTip, blockIdentifier, err := storage.AtTip(ctx, tipDelay)
 		assert.NoError(t, err)
 		assert.False(t, atTip)
+		assert.Nil(t, blockIdentifier)
 	})
 
 	t.Run("Add new block", func(t *testing.T) {
@@ -588,8 +590,12 @@ func TestAtTip(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		atTip, err := storage.AtTip(ctx, tipDelay)
+		atTip, blockIdentifier, err := storage.AtTip(ctx, tipDelay)
 		assert.NoError(t, err)
 		assert.True(t, atTip)
+		assert.Equal(t, &types.BlockIdentifier{
+			Hash:  "block 1",
+			Index: 1,
+		}, blockIdentifier)
 	})
 }

--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -75,6 +75,7 @@ func InitializeConstruction(
 	counterStorage := storage.NewCounterStorage(localStore)
 	logger := logger.NewLogger(
 		counterStorage,
+		nil,
 		dataPath,
 		false,
 		false,

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -463,7 +463,8 @@ func (t *DataTester) HandleErr(ctx context.Context, err error, sigListeners []co
 		return
 	}
 
-	if (err == nil || err == context.Canceled) && len(t.endConditionReached) == 0 && t.config.Data.EndConditions != nil && t.config.Data.EndConditions.Index != nil { // occurs at syncer end
+	if (err == nil || err == context.Canceled) && len(t.endConditionReached) == 0 && t.config.Data.EndConditions != nil &&
+		t.config.Data.EndConditions.Index != nil { // occurs at syncer end
 		t.endConditionReached = fmt.Sprintf(
 			"%s [Index: %d]",
 			configuration.IndexEndCondition,

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -173,6 +173,7 @@ func InitializeData(
 
 	reconcilerHandler := processor.NewReconcilerHandler(
 		logger,
+		balanceStorage,
 		!config.Data.IgnoreReconciliationError,
 	)
 
@@ -515,6 +516,7 @@ func (t *DataTester) recursiveOpSearch(
 
 	reconcilerHandler := processor.NewReconcilerHandler(
 		logger,
+		balanceStorage,
 		true, // halt on reconciliation error
 	)
 

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -156,8 +156,14 @@ func InitializeData(
 	blockStorage := storage.NewBlockStorage(localStore)
 	balanceStorage := storage.NewBalanceStorage(localStore)
 
+	loggerBalanceStorage := balanceStorage
+	if !shouldReconcile(config) {
+		loggerBalanceStorage = nil
+	}
+
 	logger := logger.NewLogger(
 		counterStorage,
+		loggerBalanceStorage,
 		dataPath,
 		config.Data.LogBlocks,
 		config.Data.LogTransactions,
@@ -378,7 +384,10 @@ func (t *DataTester) EndAtTipLoop(
 			}
 
 			if coverage >= minReconciliationCoverage {
-				log.Printf("syncer has reached tip and reconciliation coverage is %f%%\n", coverage*utils.OneHundred)
+				log.Printf(
+					"syncer has reached tip and reconciliation coverage is %f%%\n",
+					coverage*utils.OneHundred,
+				)
 				t.cancel()
 				return
 			}
@@ -540,6 +549,7 @@ func (t *DataTester) recursiveOpSearch(
 
 	logger := logger.NewLogger(
 		counterStorage,
+		nil,
 		tmpDir,
 		false,
 		false,


### PR DESCRIPTION
### Changes
- [x] Store `LastReconciled` in `BalanceStorage`
- [x] Add coverage reconciler end condition
- [x] Log reconciliation coverage in `check:data` stats
- [x] `Check failed: Transaction Conflict.` -> BadgerDB does not support concurrent write transactions that modify the same key
