### PR TITLE
[Enhancement] Optimize Coin Storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ go 1.13
 
 require (
 	github.com/coinbase/rosetta-sdk-go v0.3.5-0.20200812042923-73d638d69870
-	github.com/dgraph-io/badger/v2 v2.0.3
-	github.com/dgraph-io/ristretto v0.0.2 // indirect
+	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200811071800-b22eccb04321
 	github.com/ethereum/go-ethereum v1.9.18
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,11 +77,15 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200811071800-b22eccb04321 h1:LsR9nZv2ijtDtB7kyQum3KKrae/15LazuOpuHUfAriY=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200811071800-b22eccb04321/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/badger/v2 v2.0.3 h1:inzdf6VF/NZ+tJ8RwwYMjJMvsOALTHYdozn0qSl6XJI=
 github.com/dgraph-io/badger/v2 v2.0.3/go.mod h1:3KY8+bsP8wI0OEnQJAKpd4wIJW/Mm32yw2j/9FUVnIM=
 github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=

--- a/pkg/storage/balance_storage.go
+++ b/pkg/storage/balance_storage.go
@@ -505,6 +505,8 @@ func (b *BalanceStorage) getAllBalanceEntries(ctx context.Context) ([]*balanceEn
 func (b *BalanceStorage) GetAllAccountCurrency(
 	ctx context.Context,
 ) ([]*reconciler.AccountCurrency, error) {
+	log.Println("Loading previously seen accounts (this could take a while)...")
+
 	balances, err := b.getAllBalanceEntries(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("%w: unable to get all balance entries", err)

--- a/pkg/storage/coin_storage.go
+++ b/pkg/storage/coin_storage.go
@@ -68,9 +68,9 @@ func NewCoinStorage(
 // Coin represents some spendable output (typically
 // referred to as a UTXO).
 type Coin struct {
-	Identifier  *types.CoinIdentifier `json:"identifier"`
-	Transaction *types.Transaction    `json:"transaction"`
-	Operation   *types.Operation      `json:"operation"`
+	Identifier            *types.CoinIdentifier        `json:"identifier"`
+	TransactionIdentifier *types.TransactionIdentifier `json:"transaction_identifier"`
+	Operation             *types.Operation             `json:"operation"`
 }
 
 func getCoinKey(identifier *types.CoinIdentifier) []byte {
@@ -121,9 +121,9 @@ func (c *CoinStorage) tryAddingCoin(
 	coinIdentifier := operation.CoinChange.CoinIdentifier
 
 	newCoin := &Coin{
-		Identifier:  coinIdentifier,
-		Transaction: blockTransaction,
-		Operation:   operation,
+		Identifier:            coinIdentifier,
+		TransactionIdentifier: blockTransaction.TransactionIdentifier,
+		Operation:             operation,
 	}
 
 	encodedResult, err := encode(newCoin)

--- a/pkg/storage/coin_storage_test.go
+++ b/pkg/storage/coin_storage_test.go
@@ -48,30 +48,30 @@ var (
 
 	accountCoins = []*Coin{
 		{
-			Identifier:  &types.CoinIdentifier{Identifier: "coin1"},
-			Transaction: coinBlock.Transactions[0],
-			Operation:   coinBlock.Transactions[0].Operations[0],
+			Identifier:            &types.CoinIdentifier{Identifier: "coin1"},
+			TransactionIdentifier: coinBlock.Transactions[0].TransactionIdentifier,
+			Operation:             coinBlock.Transactions[0].Operations[0],
 		},
 	}
 
 	account2Coins = []*Coin{
 		{
-			Identifier:  &types.CoinIdentifier{Identifier: "coin2"},
-			Transaction: coinBlock.Transactions[0],
-			Operation:   coinBlock.Transactions[0].Operations[1],
+			Identifier:            &types.CoinIdentifier{Identifier: "coin2"},
+			TransactionIdentifier: coinBlock.Transactions[0].TransactionIdentifier,
+			Operation:             coinBlock.Transactions[0].Operations[1],
 		},
 	}
 
 	account3Coins = []*Coin{
 		{
-			Identifier:  &types.CoinIdentifier{Identifier: "coin3"},
-			Transaction: coinBlock3.Transactions[0],
-			Operation:   coinBlock3.Transactions[0].Operations[0],
+			Identifier:            &types.CoinIdentifier{Identifier: "coin3"},
+			TransactionIdentifier: coinBlock3.Transactions[0].TransactionIdentifier,
+			Operation:             coinBlock3.Transactions[0].Operations[0],
 		},
 		{
-			Identifier:  &types.CoinIdentifier{Identifier: "coin4"},
-			Transaction: coinBlock3.Transactions[1],
-			Operation:   coinBlock3.Transactions[1].Operations[0],
+			Identifier:            &types.CoinIdentifier{Identifier: "coin4"},
+			TransactionIdentifier: coinBlock3.Transactions[1].TransactionIdentifier,
+			Operation:             coinBlock3.Transactions[1].Operations[0],
 		},
 	}
 

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -478,7 +478,15 @@ func (t *DataTester) HandleErr(ctx context.Context, err error, sigListeners []co
 	}
 
 	if len(t.endCondition) != 0 {
-		Exit(t.config, t.counterStorage, t.balanceStorage, nil, 0, t.endCondition, t.endConditionDetail)
+		Exit(
+			t.config,
+			t.counterStorage,
+			t.balanceStorage,
+			nil,
+			0,
+			t.endCondition,
+			t.endConditionDetail,
+		)
 	}
 
 	fmt.Printf("\n")

--- a/pkg/tester/data_results.go
+++ b/pkg/tester/data_results.go
@@ -464,7 +464,14 @@ func Exit(
 	endCondition configuration.CheckDataEndCondition,
 	endConditionDetail string,
 ) {
-	results := ComputeCheckDataResults(config, err, counterStorage, balanceStorage, endCondition, endConditionDetail)
+	results := ComputeCheckDataResults(
+		config,
+		err,
+		counterStorage,
+		balanceStorage,
+		endCondition,
+		endConditionDetail,
+	)
 	results.Print()
 	results.Output(config.Data.ResultsOutputFile)
 


### PR DESCRIPTION
This PR introduces **significant** optimizations to `CoinStorage`. In one particular block, we went from storing ~19 GB (units in bytes):
```map[block:2757503 block-index:70 coinAccountNamespace:428288348 coinNamespace:19618926151 head-block:87 transaction-hash:1292]```

to storing ~6.8 MB (units in bytes):
```
map[block:2757503 block-index:70 coinAccountNamespace:482619 coinNamespace:4146738 head-block:87 transaction-hash:1292]
```

Naturally, such a large reduction in storage also means a significant speed boost when syncing UTXO-based blockchains (the larger the transactions, the bigger the performance increase you will observe).

### Changes
- [x] Cache reads and updates to each account identifier in a block
- [x] Only store `*types.TransactionIdentifier` in `*storage.Coin`, instead of `*types.Transaction.
- [x] Update BadgerDB to `v20.07.0`: https://github.com/dgraph-io/badger/releases/tag/v20.07.0