### PR TITLE
Binary Install Script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ salus:
 release: add-license shorten-lines format test lint salus
 
 compile:
-	xgo --targets=darwin/*,windows/*,linux/* -out bin/rosetta-cli-$(version) .
+	./scripts/compile.sh $(version)
 
 build:
 	go build ./...

--- a/README.md
+++ b/README.md
@@ -34,12 +34,10 @@ To install `rosetta-cli` from source, run:
 go get github.com/coinbase/rosetta-cli
 ```
 
-To download a binary directly for MacOS and the latest release, run:
+To download a binary directly for the latest release, run:
 ```
-curl -L https://github.com/coinbase/rosetta-cli/releases/download/v0.4.1/rosetta-cli-0.4.1-darwin-10.6-amd64 -o rosetta-cli; chmod +x rosetta-cli;
+curl -sSfL https://raw.githubusercontent.com/coinbase/rosetta-cli/master/scripts/install.sh | sh -s
 ```
-
-Otherwise, binaries for other operating systems can be found [here](https://github.com/coinbase/rosetta-cli/releases). 
 
 _Downloading binaries from the Github UI will cause permission errors on Mac._
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+VERSION=$1;
+
+xgo --targets=darwin/*,windows/*,linux/* -out "bin/rosetta-cli-${VERSION}" .;
+
+# Rename some files
+mv "bin/rosetta-cli-${VERSION}-darwin-10.6-amd64" "bin/rosetta-cli-${VERSION}-darwin-amd64" 
+mv "bin/rosetta-cli-${VERSION}-windows-4.0-amd64.exe" "bin/rosetta-cli-${VERSION}-windows-amd64"
+
+# Tar all files
+cd bin || exit;
+for i in *; do tar -czf "$i.tar.gz" "$i" && rm "$i"; done

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+# Copyright 2020 Coinbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 VERSION=$1;
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,319 @@
+#!/bin/sh
+set -e
+
+# Inspired by: https://github.com/golangci/golangci-lint/blob/master/install.sh
+
+usage() {
+  this=$1
+  cat <<EOF
+$this: download go binaries for coinbase/rosetta-cli
+
+Usage: $this [-b] bindir [-d] [tag]
+  -b sets bindir or installation directory, Defaults to ./bin
+  -d turns on debug logging
+   [tag] is a tag from
+   https://github.com/coinbase/rosetta-cli/releases
+   If tag is missing, then the latest will be used.
+
+EOF
+  exit 2
+}
+
+parse_args() {
+  #BINDIR is ./bin unless set be ENV
+  # over-ridden by flag below
+
+  BINDIR=${BINDIR:-./bin}
+  while getopts "b:dh?x" arg; do
+    case "$arg" in
+      b) BINDIR="$OPTARG" ;;
+      d) log_set_priority 10 ;;
+      h | \?) usage "$0" ;;
+      x) set -x ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+  TAG=$1
+}
+# this function wraps all the destructive operations
+# if a curl|bash cuts off the end of the script due to
+# network, either nothing will happen or will syntax error
+# out preventing half-done work
+execute() {
+  tmpdir=$(mktemp -d)
+  log_debug "downloading files into ${tmpdir}"
+  http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
+  (cd "${tmpdir}" && untar "${TARBALL}")
+  test ! -d "${BINDIR}" && install -d "${BINDIR}"
+  mv "${tmpdir}/${NAME}" "${tmpdir}/${BINARIES}"
+  install "${tmpdir}/${BINARIES}" "${BINDIR}/"
+  log_info "installed ${BINDIR}/${BINARIES}"
+  rm -rf "${tmpdir}"
+}
+get_binaries() {
+  case "$PLATFORM" in
+    darwin/amd64) BINARIES="rosetta-cli" ;;
+    linux/amd64) BINARIES="rosetta-cli" ;;
+    linux/arm64) BINARIES="rosetta-cli" ;;
+    linux/mips64) BINARIES="rosetta-cli" ;;
+    linux/mips64le) BINARIES="rosetta-cli" ;;
+    linux/ppc64le) BINARIES="rosetta-cli" ;;
+    linux/s390x) BINARIES="rosetta-cli" ;;
+    windows/amd64) BINARIES="rosetta-cli.exe" ;;
+    *)
+      log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
+      exit 1
+      ;;
+  esac
+}
+tag_to_version() {
+  if [ -z "${TAG}" ]; then
+    log_info "checking GitHub for latest tag"
+  else
+    log_info "checking GitHub for tag '${TAG}'"
+  fi
+  REALTAG=$(github_release "$OWNER/$REPO" "${TAG}") && true
+  if test -z "$REALTAG"; then
+    log_crit "unable to find '${TAG}' - use 'latest' or see https://github.com/${PREFIX}/releases for details"
+    exit 1
+  fi
+  # if version starts with 'v', remove it
+  TAG="$REALTAG"
+  VERSION=${TAG#v}
+}
+adjust_os() {
+  # adjust archive name based on OS
+  true
+}
+adjust_arch() {
+  # adjust archive name based on ARCH
+  true
+}
+
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+https://github.com/client9/shlib - portable posix shell functions
+Public domain - http://unlicense.org
+https://github.com/client9/shlib/blob/master/LICENSE.md
+but credit (and pull requests) appreciated.
+------------------------------------------------------------------------
+EOF
+is_command() {
+  command -v "$1" >/dev/null
+}
+echoerr() {
+  echo "$@" 1>&2
+}
+log_prefix() {
+  echo "$0"
+}
+_logp=6
+log_set_priority() {
+  _logp="$1"
+}
+log_priority() {
+  if test -z "$1"; then
+    echo "$_logp"
+    return
+  fi
+  [ "$1" -le "$_logp" ]
+}
+log_tag() {
+  case $1 in
+    0) echo "emerg" ;;
+    1) echo "alert" ;;
+    2) echo "crit" ;;
+    3) echo "err" ;;
+    4) echo "warning" ;;
+    5) echo "notice" ;;
+    6) echo "info" ;;
+    7) echo "debug" ;;
+    *) echo "$1" ;;
+  esac
+}
+log_debug() {
+  log_priority 7 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 7)" "$@"
+}
+log_info() {
+  log_priority 6 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 6)" "$@"
+}
+log_err() {
+  log_priority 3 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 3)" "$@"
+}
+log_crit() {
+  log_priority 2 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 2)" "$@"
+}
+uname_os() {
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  case "$os" in
+    cygwin_nt*) os="windows" ;;
+    mingw*) os="windows" ;;
+    msys_nt*) os="windows" ;;
+  esac
+  echo "$os"
+}
+uname_arch() {
+  arch=$(uname -m)
+  case $arch in
+    x86_64) arch="amd64" ;;
+    x86) arch="386" ;;
+    i686) arch="386" ;;
+    i386) arch="386" ;;
+    aarch64) arch="arm64" ;;
+    armv5*) arch="armv5" ;;
+    armv6*) arch="armv6" ;;
+    armv7*) arch="armv7" ;;
+  esac
+  echo ${arch}
+}
+uname_os_check() {
+  os=$(uname_os)
+  case "$os" in
+    darwin) return 0 ;;
+    dragonfly) return 0 ;;
+    freebsd) return 0 ;;
+    linux) return 0 ;;
+    android) return 0 ;;
+    nacl) return 0 ;;
+    netbsd) return 0 ;;
+    openbsd) return 0 ;;
+    plan9) return 0 ;;
+    solaris) return 0 ;;
+    windows) return 0 ;;
+  esac
+  log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"
+  return 1
+}
+uname_arch_check() {
+  arch=$(uname_arch)
+  case "$arch" in
+    386) return 0 ;;
+    amd64) return 0 ;;
+    arm64) return 0 ;;
+    armv5) return 0 ;;
+    armv6) return 0 ;;
+    armv7) return 0 ;;
+    ppc64) return 0 ;;
+    ppc64le) return 0 ;;
+    mips) return 0 ;;
+    mipsle) return 0 ;;
+    mips64) return 0 ;;
+    mips64le) return 0 ;;
+    s390x) return 0 ;;
+    amd64p32) return 0 ;;
+  esac
+  log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"
+  return 1
+}
+untar() {
+  tarball=$1
+  case "${tarball}" in
+    *.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
+    *.tar) tar --no-same-owner -xf "${tarball}" ;;
+    *.zip) unzip "${tarball}" ;;
+    *)
+      log_err "untar unknown archive format for ${tarball}"
+      return 1
+      ;;
+  esac
+}
+http_download_curl() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+  else
+    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+  fi
+  if [ "$code" != "200" ]; then
+    log_debug "http_download_curl received HTTP status $code"
+    return 1
+  fi
+  return 0
+}
+http_download_wget() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    wget -q -O "$local_file" "$source_url"
+  else
+    wget -q --header "$header" -O "$local_file" "$source_url"
+  fi
+}
+http_download() {
+  log_debug "http_download $2"
+  if is_command curl; then
+    http_download_curl "$@"
+    return
+  elif is_command wget; then
+    http_download_wget "$@"
+    return
+  fi
+  log_crit "http_download unable to find wget or curl"
+  return 1
+}
+http_copy() {
+  tmp=$(mktemp)
+  http_download "${tmp}" "$1" "$2" || return 1
+  body=$(cat "$tmp")
+  rm -f "${tmp}"
+  echo "$body"
+}
+github_release() {
+  owner_repo=$1
+  version=$2
+  test -z "$version" && version="latest"
+  giturl="https://github.com/${owner_repo}/releases/${version}"
+  json=$(http_copy "$giturl" "Accept:application/json")
+  test -z "$json" && return 1
+  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+  test -z "$version" && return 1
+  echo "$version"
+}
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+End of functions from https://github.com/client9/shlib
+------------------------------------------------------------------------
+EOF
+
+BINARY=rosetta-cli
+FORMAT=tar.gz
+OWNER=coinbase
+REPO="rosetta-cli"
+OS=$(uname_os)
+ARCH=$(uname_arch)
+PREFIX="$OWNER/$REPO"
+
+# use in logging routines
+log_prefix() {
+	echo "$PREFIX"
+}
+PLATFORM="${OS}/${ARCH}"
+GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
+
+uname_os_check "$OS"
+uname_arch_check "$ARCH"
+
+parse_args "$@"
+
+get_binaries
+
+tag_to_version
+
+adjust_os
+
+adjust_arch
+
+log_info "found version: ${VERSION} for ${TAG}/${OS}/${ARCH}"
+
+NAME=${BINARY}-${VERSION}-${OS}-${ARCH}
+TARBALL=${NAME}.${FORMAT}
+TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
+
+execute

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+# Copyright 2020 Coinbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 # Inspired by: https://github.com/golangci/golangci-lint/blob/master/install.sh
@@ -45,21 +59,21 @@ execute() {
   http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
   (cd "${tmpdir}" && untar "${TARBALL}")
   test ! -d "${BINDIR}" && install -d "${BINDIR}"
-  mv "${tmpdir}/${NAME}" "${tmpdir}/${BINARIES}"
-  install "${tmpdir}/${BINARIES}" "${BINDIR}/"
-  log_info "installed ${BINDIR}/${BINARIES}"
+  mv "${tmpdir}/${NAME}" "${tmpdir}/${BINARY}"
+  install "${tmpdir}/${BINARY}" "${BINDIR}/"
+  log_info "installed ${BINDIR}/${BINARY}"
   rm -rf "${tmpdir}"
 }
 get_binaries() {
   case "$PLATFORM" in
-    darwin/amd64) BINARIES="rosetta-cli" ;;
-    linux/amd64) BINARIES="rosetta-cli" ;;
-    linux/arm64) BINARIES="rosetta-cli" ;;
-    linux/mips64) BINARIES="rosetta-cli" ;;
-    linux/mips64le) BINARIES="rosetta-cli" ;;
-    linux/ppc64le) BINARIES="rosetta-cli" ;;
-    linux/s390x) BINARIES="rosetta-cli" ;;
-    windows/amd64) BINARIES="rosetta-cli.exe" ;;
+    darwin/amd64) BINARY="rosetta-cli" ;;
+    linux/amd64) BINARY="rosetta-cli" ;;
+    linux/arm64) BINARY="rosetta-cli" ;;
+    linux/mips64) BINARY="rosetta-cli" ;;
+    linux/mips64le) BINARY="rosetta-cli" ;;
+    linux/ppc64le) BINARY="rosetta-cli" ;;
+    linux/s390x) BINARY="rosetta-cli" ;;
+    windows/amd64) BINARY="rosetta-cli.exe" ;;
     *)
       log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
       exit 1


### PR DESCRIPTION
This PR adds a script to make binary installs much easier. It is inspired by https://golangci-lint.run/usage/install/#local-installation.

To test this new script on this PR, use:
```
curl -sSfL https://raw.githubusercontent.com/coinbase/rosetta-cli/patrick/install-script/scripts/install.sh | sh -s
```

### Changes
- [x] Add script to install from github releases
- [x] Change compilation script to tar all binaries