### PR TITLE
Update to v0.4.2 of rosetta-sdk-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ issues but it is highly recommended you sync from start to finish to ensure
 all correctness checks are performed.
 
 By default, account balances are looked up at specific heights (instead of
-only at the current block). If your node does not support this functionality
-set historical balance disabled to true. This will make reconciliation much
-less efficient but it will still work.
+only at the current block). If your node does not support this functionality,
+you can disable historical balance lookups in your configuration file. This will
+make reconciliation much less efficient but it will still work.
 
 If check fails due to an INACTIVE reconciliation error (balance changed without
 any corresponding operation), the cli will automatically try to find the block

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -45,9 +45,9 @@ issues but it is highly recommended you sync from start to finish to ensure
 all correctness checks are performed.
 
 By default, account balances are looked up at specific heights (instead of
-only at the current block). If your node does not support this functionality
-set historical balance disabled to true. This will make reconciliation much
-less efficient but it will still work.
+only at the current block). If your node does not support this functionality,
+you can disable historical balance lookups in your configuration file. This will
+make reconciliation much less efficient but it will still work.
 
 If check fails due to an INACTIVE reconciliation error (balance changed without
 any corresponding operation), the cli will automatically try to find the block

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -309,10 +309,6 @@ type Configuration struct {
 	// we are considered to be behind tip.
 	TipDelay int64 `json:"tip_delay"`
 
-	// DisableMemoryLimit uses a performance-optimized database mode
-	// that uses more memory.
-	DisableMemoryLimit bool `json:"disable_memory_limit"`
-
 	// LogConfiguration determines if the configuration settings
 	// should be printed to the console when a file is loaded.
 	LogConfiguration bool `json:"log_configuration"`

--- a/examples/configuration/bitcoin.json
+++ b/examples/configuration/bitcoin.json
@@ -10,7 +10,6 @@
  "max_online_connections": 0,
  "max_sync_concurrency": 0,
  "tip_delay": 1800,
- "disable_memory_limit": true,
  "log_configuration": false,
  "construction": {
   "offline_url": "",

--- a/examples/configuration/default.json
+++ b/examples/configuration/default.json
@@ -10,7 +10,6 @@
  "max_online_connections": 120,
  "max_sync_concurrency": 64,
  "tip_delay": 300,
- "disable_memory_limit": false,
  "log_configuration": false,
  "construction": null,
  "data": {

--- a/examples/configuration/ethereum.json
+++ b/examples/configuration/ethereum.json
@@ -10,7 +10,6 @@
  "max_online_connections": 0,
  "max_sync_concurrency": 0,
  "tip_delay": 60,
- "disable_memory_limit": true,
  "log_configuration": false,
  "construction": {
   "offline_url": "",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.4.2-0.20200912010944-f7d13f597014
+	github.com/coinbase/rosetta-sdk-go v0.4.2
 	github.com/fatih/color v1.9.0
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.4.2
+	github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914173330-69c73d3ff87a
 	github.com/fatih/color v1.9.0
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914173330-69c73d3ff87a
+	github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914180457-7d3458f14c0f
 	github.com/fatih/color v1.9.0
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/coinbase/rosetta-sdk-go v0.4.2-0.20200911162523-bbfbd83145d4 h1:aEQB1
 github.com/coinbase/rosetta-sdk-go v0.4.2-0.20200911162523-bbfbd83145d4/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coinbase/rosetta-sdk-go v0.4.2-0.20200912010944-f7d13f597014 h1:vMWAMtcGnpEhWh6kEDzDqviivHwFRp9w01MXGCLJCMU=
 github.com/coinbase/rosetta-sdk-go v0.4.2-0.20200912010944-f7d13f597014/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
+github.com/coinbase/rosetta-sdk-go v0.4.2 h1:ojiNdDmmMwXIVIRN9vNCPytXtRBAm+EGCibJMhQ5z8o=
+github.com/coinbase/rosetta-sdk-go v0.4.2/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/coinbase/rosetta-sdk-go v0.4.2-0.20200912010944-f7d13f597014 h1:vMWAM
 github.com/coinbase/rosetta-sdk-go v0.4.2-0.20200912010944-f7d13f597014/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coinbase/rosetta-sdk-go v0.4.2 h1:ojiNdDmmMwXIVIRN9vNCPytXtRBAm+EGCibJMhQ5z8o=
 github.com/coinbase/rosetta-sdk-go v0.4.2/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
+github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914173330-69c73d3ff87a h1:lEI5Uy/qwhjzg+DCWJG94I+k3J+iG/zs6xjowmdzBvE=
+github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914173330-69c73d3ff87a/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/coinbase/rosetta-sdk-go v0.4.2 h1:ojiNdDmmMwXIVIRN9vNCPytXtRBAm+EGCib
 github.com/coinbase/rosetta-sdk-go v0.4.2/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914173330-69c73d3ff87a h1:lEI5Uy/qwhjzg+DCWJG94I+k3J+iG/zs6xjowmdzBvE=
 github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914173330-69c73d3ff87a/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
+github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914180457-7d3458f14c0f h1:n6zV0BCXcVYilmKw8sNiRe5rc7K6R7Gb+vX25ZIvBsM=
+github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914180457-7d3458f14c0f/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -78,11 +78,7 @@ func InitializeConstruction(
 		log.Fatalf("%s: cannot create command path", err.Error())
 	}
 
-	opts := []storage.BadgerOption{}
-	if !config.DisableMemoryLimit {
-		opts = append(opts, storage.WithMemoryLimit())
-	}
-	localStore, err := storage.NewBadgerStorage(ctx, dataPath, opts...)
+	localStore, err := storage.NewBadgerStorage(ctx, dataPath)
 	if err != nil {
 		log.Fatalf("%s: unable to initialize database", err.Error())
 	}

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -141,11 +141,7 @@ func InitializeData(
 		log.Fatalf("%s: cannot create command path", err.Error())
 	}
 
-	opts := []storage.BadgerOption{}
-	if !config.DisableMemoryLimit {
-		opts = append(opts, storage.WithMemoryLimit())
-	}
-	localStore, err := storage.NewBadgerStorage(ctx, dataPath, opts...)
+	localStore, err := storage.NewBadgerStorage(ctx, dataPath)
 	if err != nil {
 		log.Fatalf("%s: unable to initialize database", err.Error())
 	}
@@ -580,11 +576,7 @@ func (t *DataTester) recursiveOpSearch(
 	}
 	defer utils.RemoveTempDir(tmpDir)
 
-	opts := []storage.BadgerOption{}
-	if !t.config.DisableMemoryLimit {
-		opts = append(opts, storage.WithMemoryLimit())
-	}
-	localStore, err := storage.NewBadgerStorage(ctx, tmpDir, opts...)
+	localStore, err := storage.NewBadgerStorage(ctx, tmpDir)
 	if err != nil {
 		return nil, fmt.Errorf("%w: unable to initialize database", err)
 	}

--- a/pkg/tester/data_results.go
+++ b/pkg/tester/data_results.go
@@ -284,7 +284,10 @@ func (c *CheckDataTests) Print() {
 // indicating if all endpoints received
 // a non-500 response.
 func RequestResponseTest(err error) bool {
-	return !(fetcher.Err(err) || errors.Is(err, utils.ErrNetworkNotSupported))
+	return !(fetcher.Err(err) ||
+		errors.Is(err, utils.ErrNetworkNotSupported) ||
+		errors.Is(err, syncer.ErrGetNetworkStatusFailed) ||
+		errors.Is(err, syncer.ErrFetchBlockFailed))
 }
 
 // ResponseAssertionTest returns a boolean

--- a/pkg/tester/data_results_test.go
+++ b/pkg/tester/data_results_test.go
@@ -91,6 +91,20 @@ func TestComputeCheckDataResults(t *testing.T) {
 				},
 			},
 		},
+		"default configuration, no storage, syncer and fetch errors": {
+			cfg: configuration.DefaultConfiguration(),
+			err: []error{
+				syncer.ErrGetNetworkStatusFailed,
+				syncer.ErrFetchBlockFailed,
+			},
+			result: &CheckDataResults{
+				Tests: &CheckDataTests{
+					RequestResponse:   false,
+					ResponseAssertion: true,
+					BlockSyncing:      &f,
+				},
+			},
+		},
 		"default configuration, no storage, assertion errors": {
 			cfg: configuration.DefaultConfiguration(),
 			err: []error{asserter.ErrAmountValueMissing},


### PR DESCRIPTION
This PR updates `rosetta-cli` to use the newest release of `rosetta-sdk-go`.

### Changes
- [x] Update to [`v0.4.2`](https://github.com/coinbase/rosetta-sdk-go/releases/tag/v0.4.2) release of `rosetta-sdk-go`
- [x] Remove `limit_memory` setting from configuration (we do memory management as part of `rosetta-sdk-go/storage` now)