### PR TITLE
Support Automated Fund Return

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ deps:
 	go get ./...
 
 lint:
-	golangci-lint run -v \
+	golangci-lint run --timeout 2m0s -v \
 		-E golint,misspell,gocyclo,whitespace,goconst,gocritic,gocognit,bodyclose,unconvert,lll,unparam,gomnd;
 
 format:

--- a/cmd/check_construction.go
+++ b/cmd/check_construction.go
@@ -132,8 +132,8 @@ func runCheckConstructionCmd(cmd *cobra.Command, args []string) {
 	})
 
 	sigListeners := []context.CancelFunc{cancel}
-	go handleSignals(sigListeners)
+	go handleSignals(&sigListeners)
 
 	err = g.Wait()
-	constructionTester.HandleErr(err)
+	constructionTester.HandleErr(err, &sigListeners)
 }

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -138,7 +138,7 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 	})
 
 	sigListeners := []context.CancelFunc{cancel}
-	go handleSignals(sigListeners)
+	go handleSignals(&sigListeners)
 
 	err = g.Wait()
 
@@ -148,5 +148,5 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 
 	// HandleErr will exit if we should not attempt
 	// to find missing operations.
-	dataTester.HandleErr(ctx, err, sigListeners)
+	dataTester.HandleErr(ctx, err, &sigListeners)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,6 +132,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.5.1")
+		fmt.Println("v0.5.2")
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,14 +115,14 @@ func ensureDataDirectoryExists() {
 // handleSignals handles OS signals so we can ensure we close database
 // correctly. We call multiple sigListeners because we
 // may need to cancel more than 1 context.
-func handleSignals(listeners []context.CancelFunc) {
+func handleSignals(listeners *[]context.CancelFunc) {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigs
 		color.Red("Received signal: %s", sig)
 		SignalReceived = true
-		for _, listener := range listeners {
+		for _, listener := range *listeners {
 			listener()
 		}
 	}()

--- a/examples/configuration/bitcoin.json
+++ b/examples/configuration/bitcoin.json
@@ -3,16 +3,15 @@
   "blockchain": "Bitcoin",
   "network": "Testnet3"
  },
- "online_url": "",
  "data_directory": "bitcoin-data",
  "http_timeout": 300,
+ "max_retries": 5,
  "retry_elapsed_time": 0,
  "max_online_connections": 0,
  "max_sync_concurrency": 0,
  "tip_delay": 1800,
  "log_configuration": false,
  "construction": {
-  "offline_url": "",
   "max_offline_connections": 0,
   "stale_depth": 0,
   "broadcast_limit": 0,
@@ -88,12 +87,12 @@
     "concurrency": 10,
     "scenarios": [
      {
-      "name": "transfer",
+      "name": "transfer_dry_run",
       "actions": [
        {
         "input": "{\"network\":\"Testnet3\", \"blockchain\":\"Bitcoin\"}",
         "type": "set_variable",
-        "output_path": "transfer.network"
+        "output_path": "transfer_dry_run.network"
        },
        {
         "input": "{\"symbol\":\"tBTC\", \"decimals\":8}",
@@ -106,17 +105,17 @@
         "output_path": "dust_amount"
        },
        {
-        "input": "\"600\"",
+        "input": "\"1200\"",
         "type": "set_variable",
-        "output_path": "fee_amount"
+        "output_path": "max_fee_amount"
        },
        {
-        "input": "{\"operation\":\"addition\", \"left_value\": {{dust_amount}}, \"right_value\": {{fee_amount}}}",
+        "input": "{\"operation\":\"addition\", \"left_value\": {{dust_amount}}, \"right_value\": {{max_fee_amount}}}",
         "type": "math",
         "output_path": "send_buffer"
        },
        {
-        "input": "\"1800\"",
+        "input": "\"2400\"",
         "type": "set_variable",
         "output_path": "reserved_amount"
        },
@@ -142,10 +141,10 @@
        {
         "input": "{\"operation\":\"subtraction\", \"left_value\": {{sender.balance.value}}, \"right_value\": {{recipient_amount}}}",
         "type": "math",
-        "output_path": "change_amount"
+        "output_path": "total_change_amount"
        },
        {
-        "input": "{\"operation\":\"subtraction\", \"left_value\": {{change_amount}}, \"right_value\": {{fee_amount}}}",
+        "input": "{\"operation\":\"subtraction\", \"left_value\": {{total_change_amount}}, \"right_value\": {{max_fee_amount}}}",
         "type": "math",
         "output_path": "change_amount"
        },
@@ -162,6 +161,45 @@
         "input": "{\"not_account_identifier\":[{{sender.account_identifier}}], \"not_coins\":[{{sender.coin}}], \"minimum_balance\":{\"value\": \"0\", \"currency\": {{currency}}}, \"create_limit\": 100, \"create_probability\": 50}",
         "type": "find_balance",
         "output_path": "recipient"
+       },
+       {
+        "input": "\"1\"",
+        "type": "set_variable",
+        "output_path": "transfer_dry_run.confirmation_depth"
+       },
+       {
+        "input": "\"true\"",
+        "type": "set_variable",
+        "output_path": "transfer_dry_run.dry_run"
+       },
+       {
+        "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"INPUT\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}, \"coin_change\":{\"coin_action\":\"coin_spent\", \"coin_identifier\":{{sender.coin}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"OUTPUT\",\"account\":{{recipient.account_identifier}},\"amount\":{\"value\":{{recipient_amount}},\"currency\":{{currency}}}}, {\"operation_identifier\":{\"index\":2},\"type\":\"OUTPUT\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{change_amount}},\"currency\":{{currency}}}}]",
+        "type": "set_variable",
+        "output_path": "transfer_dry_run.operations"
+       },
+       {
+        "input": "{{transfer_dry_run.operations}}",
+        "type": "print_message"
+       }
+      ]
+     },
+     {
+      "name": "transfer",
+      "actions": [
+       {
+        "input": "{\"currency\":{{currency}}, \"amounts\":{{transfer_dry_run.suggested_fee}}}",
+        "type": "find_currency_amount",
+        "output_path": "suggested_fee"
+       },
+       {
+        "input": "{\"operation\":\"subtraction\", \"left_value\": {{total_change_amount}}, \"right_value\": {{suggested_fee.value}}}",
+        "type": "math",
+        "output_path": "change_amount"
+       },
+       {
+        "input": "{\"network\":\"Testnet3\", \"blockchain\":\"Bitcoin\"}",
+        "type": "set_variable",
+        "output_path": "transfer.network"
        },
        {
         "input": "\"1\"",

--- a/examples/configuration/bitcoin.json
+++ b/examples/configuration/bitcoin.json
@@ -197,6 +197,15 @@
         "output_path": "change_amount"
        },
        {
+        "input": "{\"operation\":\"subtraction\", \"left_value\": {{change_amount}}, \"right_value\": {{dust_amount}}}",
+        "type": "math",
+        "output_path": "change_minus_dust"
+       },
+       {
+        "input": "{{change_minus_dust}}",
+        "type": "assert"
+       },
+       {
         "input": "{\"network\":\"Testnet3\", \"blockchain\":\"Bitcoin\"}",
         "type": "set_variable",
         "output_path": "transfer.network"
@@ -208,6 +217,128 @@
        },
        {
         "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"INPUT\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}, \"coin_change\":{\"coin_action\":\"coin_spent\", \"coin_identifier\":{{sender.coin}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"OUTPUT\",\"account\":{{recipient.account_identifier}},\"amount\":{\"value\":{{recipient_amount}},\"currency\":{{currency}}}}, {\"operation_identifier\":{\"index\":2},\"type\":\"OUTPUT\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{change_amount}},\"currency\":{{currency}}}}]",
+        "type": "set_variable",
+        "output_path": "transfer.operations"
+       },
+       {
+        "input": "{{transfer.operations}}",
+        "type": "print_message"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "name": "return_funds",
+    "concurrency": 10,
+    "scenarios": [
+     {
+      "name": "transfer_dry_run",
+      "actions": [
+       {
+        "input": "{\"network\":\"Testnet3\", \"blockchain\":\"Bitcoin\"}",
+        "type": "set_variable",
+        "output_path": "transfer_dry_run.network"
+       },
+       {
+        "input": "{\"symbol\":\"tBTC\", \"decimals\":8}",
+        "type": "set_variable",
+        "output_path": "currency"
+       },
+       {
+        "input": "\"1200\"",
+        "type": "set_variable",
+        "output_path": "max_fee_amount"
+       },
+       {
+        "input": "\"1800\"",
+        "type": "set_variable",
+        "output_path": "reserved_amount"
+       },
+       {
+        "input": "{\"require_coin\":true, \"minimum_balance\":{\"value\": {{reserved_amount}}, \"currency\": {{currency}}}}",
+        "type": "find_balance",
+        "output_path": "sender"
+       },
+       {
+        "input": "{\"operation\":\"subtraction\", \"left_value\": {{sender.balance.value}}, \"right_value\": {{max_fee_amount}}}",
+        "type": "math",
+        "output_path": "recipient_amount"
+       },
+       {
+        "input": "{\"recipient_amount\":{{recipient_amount}}}",
+        "type": "print_message"
+       },
+       {
+        "input": "{\"operation\":\"subtraction\", \"left_value\": \"0\", \"right_value\":{{sender.balance.value}}}",
+        "type": "math",
+        "output_path": "sender_amount"
+       },
+       {
+        "input": "\"1\"",
+        "type": "set_variable",
+        "output_path": "transfer_dry_run.confirmation_depth"
+       },
+       {
+        "input": "\"true\"",
+        "type": "set_variable",
+        "output_path": "transfer_dry_run.dry_run"
+       },
+       {
+        "input": "{\"address\": \"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt\"}",
+        "type": "set_variable",
+        "output_path": "recipient"
+       },
+       {
+        "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"INPUT\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}, \"coin_change\":{\"coin_action\":\"coin_spent\", \"coin_identifier\":{{sender.coin}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"OUTPUT\",\"account\":{{recipient}},\"amount\":{\"value\":{{recipient_amount}},\"currency\":{{currency}}}}]",
+        "type": "set_variable",
+        "output_path": "transfer_dry_run.operations"
+       },
+       {
+        "input": "{{transfer_dry_run.operations}}",
+        "type": "print_message"
+       }
+      ]
+     },
+     {
+      "name": "transfer",
+      "actions": [
+       {
+        "input": "{\"currency\":{{currency}}, \"amounts\":{{transfer_dry_run.suggested_fee}}}",
+        "type": "find_currency_amount",
+        "output_path": "suggested_fee"
+       },
+       {
+        "input": "{\"operation\":\"subtraction\", \"left_value\": {{sender.balance.value}}, \"right_value\": {{suggested_fee.value}}}",
+        "type": "math",
+        "output_path": "recipient_amount"
+       },
+       {
+        "input": "\"600\"",
+        "type": "set_variable",
+        "output_path": "dust_amount"
+       },
+       {
+        "input": "{\"operation\":\"subtraction\", \"left_value\": {{recipient_amount}}, \"right_value\": {{dust_amount}}}",
+        "type": "math",
+        "output_path": "recipient_minus_dust"
+       },
+       {
+        "input": "{{recipient_minus_dust}}",
+        "type": "assert"
+       },
+       {
+        "input": "{\"network\":\"Testnet3\", \"blockchain\":\"Bitcoin\"}",
+        "type": "set_variable",
+        "output_path": "transfer.network"
+       },
+       {
+        "input": "\"1\"",
+        "type": "set_variable",
+        "output_path": "transfer.confirmation_depth"
+       },
+       {
+        "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"INPUT\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}, \"coin_change\":{\"coin_action\":\"coin_spent\", \"coin_identifier\":{{sender.coin}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"OUTPUT\",\"account\":{{recipient}},\"amount\":{\"value\":{{recipient_amount}},\"currency\":{{currency}}}}]",
         "type": "set_variable",
         "output_path": "transfer.operations"
        },

--- a/examples/configuration/ethereum.json
+++ b/examples/configuration/ethereum.json
@@ -6,6 +6,7 @@
  "online_url": "",
  "data_directory": "ethereum-data",
  "http_timeout": 300,
+ "max_retries": 5,
  "retry_elapsed_time": 0,
  "max_online_connections": 0,
  "max_sync_concurrency": 0,
@@ -141,6 +142,66 @@
        },
        {
         "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"transfer\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"transfer\",\"account\":{{recipient.account_identifier}},\"amount\":{\"value\":{{recipient_amount}},\"currency\":{{currency}}}}]",
+        "type": "set_variable",
+        "output_path": "transfer.operations"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "name": "return_funds",
+    "concurrency": 10,
+    "scenarios": [
+     {
+      "name": "transfer",
+      "actions": [
+       {
+        "input": "{\"network\":\"Ropsten\", \"blockchain\":\"Ethereum\"}",
+        "type": "set_variable",
+        "output_path": "transfer.network"
+       },
+       {
+        "input": "{\"symbol\":\"ETH\", \"decimals\":18}",
+        "type": "set_variable",
+        "output_path": "currency"
+       },
+       {
+        "input": "\"42000000000000\"",
+        "type": "set_variable",
+        "output_path": "max_fee"
+       },
+       {
+        "input": "{\"minimum_balance\":{\"value\": {{max_fee}}, \"currency\": {{currency}}}}",
+        "type": "find_balance",
+        "output_path": "sender"
+       },
+       {
+        "input": "{\"operation\":\"subtraction\", \"left_value\": {{sender.balance.value}}, \"right_value\": {{max_fee}}}",
+        "type": "math",
+        "output_path": "available_amount"
+       },
+       {
+        "input": "{\"return_amount\":{{available_amount}}}",
+        "type": "print_message"
+       },
+       {
+        "input": "{\"operation\":\"subtraction\", \"left_value\": \"0\", \"right_value\":{{available_amount}}}",
+        "type": "math",
+        "output_path": "sender_amount"
+       },
+       {
+        "input": "{\"address\":\"0xb41B39479a525AB69e38c701A713D98E3074252c\"}",
+        "type": "set_variable",
+        "output_path": "faucet"
+       },
+       {
+        "input": "\"1\"",
+        "type": "set_variable",
+        "output_path": "transfer.confirmation_depth"
+       },
+       {
+        "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"transfer\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"transfer\",\"account\":{{faucet}},\"amount\":{\"value\":{{available_amount}},\"currency\":{{currency}}}}]",
         "type": "set_variable",
         "output_path": "transfer.operations"
        }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.4.4-0.20200916005026-5f676c313cfc
+	github.com/coinbase/rosetta-sdk-go v0.4.4
 	github.com/fatih/color v1.9.0
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.4.3
+	github.com/coinbase/rosetta-sdk-go v0.4.4-0.20200916005026-5f676c313cfc
 	github.com/fatih/color v1.9.0
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914180457-7d3458f14c0f
+	github.com/coinbase/rosetta-sdk-go v0.4.3
 	github.com/fatih/color v1.9.0
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/coinbase/rosetta-sdk-go v0.4.4-0.20200916003715-bc5c0dc3f67f h1:Phzxs
 github.com/coinbase/rosetta-sdk-go v0.4.4-0.20200916003715-bc5c0dc3f67f/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coinbase/rosetta-sdk-go v0.4.4-0.20200916005026-5f676c313cfc h1:huzflMX5sJfrDIhv1p+D9U60jr/WC8qzJJ2EVgAazmU=
 github.com/coinbase/rosetta-sdk-go v0.4.4-0.20200916005026-5f676c313cfc/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
+github.com/coinbase/rosetta-sdk-go v0.4.4 h1:zTUS4bVlTfD4xq/o6JtsuU+g9sf3+S3Nnn2A24Ycow4=
+github.com/coinbase/rosetta-sdk-go v0.4.4/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,10 @@ github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914180457-7d3458f14c0f h1:n6zV0
 github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914180457-7d3458f14c0f/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coinbase/rosetta-sdk-go v0.4.3 h1:qj1U6h7textY92kmjtQmWYN+REup17+cDcNVL9drPwA=
 github.com/coinbase/rosetta-sdk-go v0.4.3/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
+github.com/coinbase/rosetta-sdk-go v0.4.4-0.20200916003715-bc5c0dc3f67f h1:Phzxs8VyctyVzRzMzAml/nLOYpNw/uTfD2cZe8wyEqU=
+github.com/coinbase/rosetta-sdk-go v0.4.4-0.20200916003715-bc5c0dc3f67f/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
+github.com/coinbase/rosetta-sdk-go v0.4.4-0.20200916005026-5f676c313cfc h1:huzflMX5sJfrDIhv1p+D9U60jr/WC8qzJJ2EVgAazmU=
+github.com/coinbase/rosetta-sdk-go v0.4.4-0.20200916005026-5f676c313cfc/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914173330-69c73d3ff87a h1:lEI5U
 github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914173330-69c73d3ff87a/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914180457-7d3458f14c0f h1:n6zV0BCXcVYilmKw8sNiRe5rc7K6R7Gb+vX25ZIvBsM=
 github.com/coinbase/rosetta-sdk-go v0.4.3-0.20200914180457-7d3458f14c0f/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
+github.com/coinbase/rosetta-sdk-go v0.4.3 h1:qj1U6h7textY92kmjtQmWYN+REup17+cDcNVL9drPwA=
+github.com/coinbase/rosetta-sdk-go v0.4.3/go.mod h1:Luv0AhzZH81eul2hYZ3w0hBGwmFPiexwbntYxihEZck=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -35,6 +35,7 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/coinbase/rosetta-sdk-go/utils"
 	"github.com/fatih/color"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -382,8 +383,52 @@ func (t *ConstructionTester) WatchEndConditions(
 	}
 }
 
+func (t *ConstructionTester) returnFunds(
+	ctx context.Context,
+	sigListeners *[]context.CancelFunc,
+) {
+	// To cancel all execution, need to call multiple cancel functions.
+	ctx, cancel := context.WithCancel(ctx)
+	*sigListeners = append(*sigListeners, cancel)
+
+	var returnFundsSuccess bool
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return t.StartSyncer(ctx, cancel)
+	})
+	g.Go(func() error {
+		return t.StartPeriodicLogger(ctx)
+	})
+	g.Go(func() error {
+		err := t.coordinator.ReturnFunds(ctx)
+
+		// If the error is nil, we need to cancel the syncer
+		// or we will sync forever.
+		if err == nil {
+			returnFundsSuccess = true // makes error parsing much easier
+			cancel()
+			return nil
+		}
+
+		return err
+	})
+
+	err := g.Wait()
+	if *t.signalReceived {
+		color.Red("Fund return halted")
+		return
+	}
+
+	if !returnFundsSuccess {
+		log.Printf("unable to return funds %v\n", err)
+	}
+}
+
 // HandleErr is called when `check:construction` returns an error.
-func (t *ConstructionTester) HandleErr(err error) {
+func (t *ConstructionTester) HandleErr(
+	err error,
+	sigListeners *[]context.CancelFunc,
+) {
 	if *t.signalReceived {
 		color.Red("Check halted")
 		os.Exit(1)
@@ -397,10 +442,10 @@ func (t *ConstructionTester) HandleErr(err error) {
 	// We optimistically run the ReturnFunds function on the coordinator
 	// and only log if it fails. If there is no ReturnFunds workflow defined,
 	// this will just return nil.
-	returnCtx := context.Background()
-	if err := t.coordinator.ReturnFunds(returnCtx); err != nil {
-		log.Printf("return funds failed: %v\n", err)
-	}
+	t.returnFunds(
+		context.Background(),
+		sigListeners,
+	)
 
 	ExitConstruction(t.config, t.counterStorage, t.jobStorage, nil, 0)
 }

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -676,10 +676,14 @@ func (t *DataTester) recursiveOpSearch(
 	}
 
 	if *t.signalReceived {
-		return nil, errors.New("Search for block with missing ops halted")
+		return nil, errors.New("search for block with missing ops halted")
 	}
 
 	if err == nil || errors.Is(err, context.Canceled) {
+		if startIndex <= t.genesisBlock.Index {
+			return nil, errors.New("unable to find missing ops")
+		}
+
 		newStart := startIndex - InactiveFailureLookbackWindow
 		if newStart < t.genesisBlock.Index {
 			newStart = t.genesisBlock.Index

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -478,7 +478,7 @@ func (t *DataTester) WatchEndConditions(
 // HandleErr is called when `check:data` returns an error.
 // If historical balance lookups are enabled, HandleErr will attempt to
 // automatically find any missing balance-changing operations.
-func (t *DataTester) HandleErr(ctx context.Context, err error, sigListeners []context.CancelFunc) {
+func (t *DataTester) HandleErr(ctx context.Context, err error, sigListeners *[]context.CancelFunc) {
 	if *t.signalReceived {
 		color.Red("Check halted")
 		os.Exit(1)
@@ -533,12 +533,12 @@ func (t *DataTester) HandleErr(ctx context.Context, err error, sigListeners []co
 func (t *DataTester) FindMissingOps(
 	ctx context.Context,
 	originalErr error,
-	sigListeners []context.CancelFunc,
+	sigListeners *[]context.CancelFunc,
 ) {
 	color.Cyan("Searching for block with missing operations...hold tight")
 	badBlock, err := t.recursiveOpSearch(
 		ctx,
-		&sigListeners,
+		sigListeners,
 		t.reconcilerHandler.InactiveFailure,
 		t.reconcilerHandler.InactiveFailureBlock.Index-InactiveFailureLookbackWindow,
 		t.reconcilerHandler.InactiveFailureBlock.Index,
@@ -679,7 +679,7 @@ func (t *DataTester) recursiveOpSearch(
 		return nil, errors.New("Search for block with missing ops halted")
 	}
 
-	if err == nil || err == context.Canceled {
+	if err == nil || errors.Is(err, context.Canceled) {
 		newStart := startIndex - InactiveFailureLookbackWindow
 		if newStart < t.genesisBlock.Index {
 			newStart = t.genesisBlock.Index


### PR DESCRIPTION
Closes: #119 
Closes: #112 

This PR adds support for automated fund return when reaching `check:construction` end conditions. This PR also includes updates to the `bitcoin.json` configuration file that demonstrate how to use the new `dry_run` feature to populate suggested fee.

### Changes
- [x] update to [`rosetta-sdk-go@v0.4.4`](https://github.com/coinbase/rosetta-sdk-go/releases/tag/v0.4.4)
- [x] invoke `coordinator.ReturnFunds` after reaching exit conditions
- [x] output a colored log when attempting to return funds (https://github.com/coinbase/rosetta-sdk-go/pull/158)
- [x] update `ethereum.json` to support `ReturnFunds`
- [x] update `bitcoin.json` to support `DryRun`
- [x] update `bitcoin.json` to support `ReturnFunds`
- [x] Update `bitcoin.json` to include assertion for fee
- [x] fix dbTx locking on exit condition abort (https://github.com/coinbase/rosetta-sdk-go/pull/160)
- [x] update README with updated info about end conditions and how to use construction API tester
- [x] closes: #84 
- [x] update version to `v0.5.2`