### PR TITLE
[Cmd] Fix Error on Exit

### DIFF
--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -66,11 +66,11 @@ historical balance disabled to true, you must provide an
 absolute path to a JSON file containing initial balances with the
 bootstrap balance config. You can look at the examples folder for an example
 of what one of these files looks like.`,
-		Run: runCheckDataCmd,
+		RunE: runCheckDataCmd,
 	}
 )
 
-func runCheckDataCmd(cmd *cobra.Command, args []string) {
+func runCheckDataCmd(cmd *cobra.Command, args []string) error {
 	ensureDataDirectoryExists()
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -84,12 +84,12 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 
 	_, _, fetchErr := fetcher.InitializeAsserter(ctx, Config.Network)
 	if fetchErr != nil {
-		results.ExitData(
+		cancel()
+		return results.ExitData(
 			Config,
 			nil,
 			nil,
 			fmt.Errorf("%w: unable to initialize asserter", fetchErr.Err),
-			1,
 			"",
 			"",
 		)
@@ -97,12 +97,12 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 
 	networkStatus, err := utils.CheckNetworkSupported(ctx, Config.Network, fetcher)
 	if err != nil {
-		results.ExitData(
+		cancel()
+		return results.ExitData(
 			Config,
 			nil,
 			nil,
 			fmt.Errorf("%w: unable to confirm network", err),
-			1,
 			"",
 			"",
 		)
@@ -166,5 +166,5 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) {
 
 	// HandleErr will exit if we should not attempt
 	// to find missing operations.
-	dataTester.HandleErr(ctx, err, &sigListeners)
+	return dataTester.HandleErr(ctx, err, &sigListeners)
 }

--- a/cmd/configuration_create.go
+++ b/cmd/configuration_create.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"log"
+	"fmt"
 
 	"github.com/coinbase/rosetta-cli/configuration"
 
@@ -27,13 +27,15 @@ var (
 	configurationCreateCmd = &cobra.Command{
 		Use:   "configuration:create",
 		Short: "Create a default configuration file at the provided path",
-		Run:   runConfigurationCreateCmd,
+		RunE:  runConfigurationCreateCmd,
 		Args:  cobra.ExactArgs(1),
 	}
 )
 
-func runConfigurationCreateCmd(cmd *cobra.Command, args []string) {
+func runConfigurationCreateCmd(cmd *cobra.Command, args []string) error {
 	if err := utils.SerializeAndWrite(args[0], configuration.DefaultConfiguration()); err != nil {
-		log.Fatalf("%s: unable to save configuration file to %s", err.Error(), args[0])
+		return fmt.Errorf("%w: unable to save configuration file to %s", err, args[0])
 	}
+
+	return nil
 }

--- a/cmd/configuration_validate.go
+++ b/cmd/configuration_validate.go
@@ -15,10 +15,11 @@
 package cmd
 
 import (
-	"log"
+	"fmt"
 
 	"github.com/coinbase/rosetta-cli/configuration"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -26,16 +27,17 @@ var (
 	configurationValidateCmd = &cobra.Command{
 		Use:   "configuration:validate",
 		Short: "Ensure a configuration file at the provided path is formatted correctly",
-		Run:   runConfigurationValidateCmd,
+		RunE:  runConfigurationValidateCmd,
 		Args:  cobra.ExactArgs(1),
 	}
 )
 
-func runConfigurationValidateCmd(cmd *cobra.Command, args []string) {
+func runConfigurationValidateCmd(cmd *cobra.Command, args []string) error {
 	_, err := configuration.LoadConfiguration(args[0])
 	if err != nil {
-		log.Fatalf("%s: unable to save configuration file to %s", err.Error(), args[0])
+		return fmt.Errorf("%w: unable to save configuration file to %s", err, args[0])
 	}
 
-	log.Println("Configuration file validated!")
+	color.Green("Configuration file validated!")
+	return nil
 }

--- a/cmd/utils_asserter_configuration.go
+++ b/cmd/utils_asserter_configuration.go
@@ -16,11 +16,12 @@ package cmd
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/utils"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -36,12 +37,12 @@ have been added in an update instead of silently erroring.
 
 To use this command, simply provide an absolute path as the argument for where
 the configuration file should be saved (in JSON).`,
-		Run:  runCreateConfigurationCmd,
+		RunE: runCreateConfigurationCmd,
 		Args: cobra.ExactArgs(1),
 	}
 )
 
-func runCreateConfigurationCmd(cmd *cobra.Command, args []string) {
+func runCreateConfigurationCmd(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// Create a new fetcher
@@ -55,15 +56,18 @@ func runCreateConfigurationCmd(cmd *cobra.Command, args []string) {
 	// Initialize the fetcher's asserter
 	_, _, fetchErr := newFetcher.InitializeAsserter(ctx, Config.Network)
 	if fetchErr != nil {
-		log.Fatalf("%s: failed to initialize asserter", fetchErr.Err.Error())
+		return fmt.Errorf("%w: failed to initialize asserter", fetchErr.Err)
 	}
 
 	configuration, err := newFetcher.Asserter.ClientConfiguration()
 	if err != nil {
-		log.Fatalf("%s: unable to generate spec", err.Error())
+		return fmt.Errorf("%w: unable to generate spec", err)
 	}
 
 	if err := utils.SerializeAndWrite(args[0], configuration); err != nil {
-		log.Fatalf("%s: unable to serialize asserter configuration", err.Error())
+		return fmt.Errorf("%w: unable to serialize asserter configuration", err)
 	}
+
+	color.Green("Configuration file saved!")
+	return nil
 }

--- a/cmd/utils_train_zstd.go
+++ b/cmd/utils_train_zstd.go
@@ -16,11 +16,13 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"path"
 	"strconv"
 
 	"github.com/coinbase/rosetta-sdk-go/storage"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -43,12 +45,12 @@ The arguments for this command are:
 
 You can learn more about dictionary compression on the Zstandard
 website: https://github.com/facebook/zstd#the-case-for-small-data-compression`,
-		Run:  runTrainZstdCmd,
+		RunE: runTrainZstdCmd,
 		Args: cobra.MinimumNArgs(trainArgs),
 	}
 )
 
-func runTrainZstdCmd(cmd *cobra.Command, args []string) {
+func runTrainZstdCmd(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	namespace := args[0]
@@ -56,7 +58,7 @@ func runTrainZstdCmd(cmd *cobra.Command, args []string) {
 	dictionaryPath := path.Clean(args[2])
 	maxItems, err := strconv.Atoi(args[3])
 	if err != nil {
-		log.Fatalf("%s: unable to convert max items to integer", err.Error())
+		return fmt.Errorf("%w: unable to convert max items to integer", err)
 	}
 
 	compressorEntries := []*storage.CompressorEntry{}
@@ -80,6 +82,9 @@ func runTrainZstdCmd(cmd *cobra.Command, args []string) {
 		compressorEntries,
 	)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("%w: badger training failed", err)
 	}
+
+	color.Green("Training successful!")
+	return nil
 }

--- a/cmd/view_account.go
+++ b/cmd/view_account.go
@@ -41,21 +41,21 @@ any account by providing a JSON representation of a types.AccountIdentifier
 For example, you could run view:account '{"address":"interesting address"}' 1000
 to lookup the balance of an interesting address at block 1000. Allowing the
 address to specified as JSON allows for querying by SubAccountIdentifier.`,
-		Run:  runViewAccountCmd,
+		RunE: runViewAccountCmd,
 		Args: cobra.MinimumNArgs(1),
 	}
 )
 
-func runViewAccountCmd(cmd *cobra.Command, args []string) {
+func runViewAccountCmd(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	account := &types.AccountIdentifier{}
 	if err := json.Unmarshal([]byte(args[0]), account); err != nil {
-		log.Fatal(fmt.Errorf("%w: unable to unmarshal account %s", err, args[0]))
+		return fmt.Errorf("%w: unable to unmarshal account %s", err, args[0])
 	}
 
 	if err := asserter.AccountIdentifier(account); err != nil {
-		log.Fatal(fmt.Errorf("%w: invalid account identifier %+v", err, account))
+		return fmt.Errorf("%w: invalid account identifier %s", err, types.PrintStruct(account))
 	}
 
 	// Create a new fetcher
@@ -69,19 +69,19 @@ func runViewAccountCmd(cmd *cobra.Command, args []string) {
 	// Initialize the fetcher's asserter
 	_, _, fetchErr := newFetcher.InitializeAsserter(ctx, Config.Network)
 	if fetchErr != nil {
-		log.Fatal(fetchErr.Err)
+		return fmt.Errorf("%w: unable to initialize asserter", fetchErr.Err)
 	}
 
 	_, err := utils.CheckNetworkSupported(ctx, Config.Network, newFetcher)
 	if err != nil {
-		log.Fatalf("%s: unable to confirm network is supported", err.Error())
+		return fmt.Errorf("%w: unable to confirm network is supported", err)
 	}
 
 	var lookupBlock *types.PartialBlockIdentifier
 	if len(args) > 1 {
 		index, err := strconv.ParseInt(args[1], 10, 64)
 		if err != nil {
-			log.Fatal(fmt.Errorf("%w: unable to parse index %s", err, args[0]))
+			return fmt.Errorf("%w: unable to parse index %s", err, args[0])
 		}
 
 		lookupBlock = &types.PartialBlockIdentifier{Index: &index}
@@ -94,11 +94,13 @@ func runViewAccountCmd(cmd *cobra.Command, args []string) {
 		lookupBlock,
 	)
 	if fetchErr != nil {
-		log.Fatal(fmt.Errorf("%w: unable to fetch account %+v", fetchErr.Err, account))
+		return fmt.Errorf("%w: unable to fetch account %+v", fetchErr.Err, account)
 	}
 
 	log.Printf("Amounts: %s\n", types.PrettyPrintStruct(amounts))
 	log.Printf("Coins: %s\n", types.PrettyPrintStruct(coins))
 	log.Printf("Metadata: %s\n", types.PrettyPrintStruct(metadata))
 	log.Printf("Balance Fetched At: %s\n", types.PrettyPrintStruct(block))
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -15,13 +15,17 @@
 package main
 
 import (
-	"log"
+	"os"
 
 	"github.com/coinbase/rosetta-cli/cmd"
+
+	"github.com/fatih/color"
 )
 
 func main() {
-	if err := cmd.Execute(); err != nil {
-		log.Fatal(err)
+	err := cmd.Execute()
+	if err != nil {
+		color.Red("Command Failed: %s", err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/results/construction_results.go
+++ b/pkg/results/construction_results.go
@@ -296,8 +296,7 @@ func ExitConstruction(
 	counterStorage *storage.CounterStorage,
 	jobStorage *storage.JobStorage,
 	err error,
-	status int,
-) {
+) error {
 	results := ComputeCheckConstructionResults(
 		config,
 		err,
@@ -309,5 +308,5 @@ func ExitConstruction(
 		results.Output(config.Construction.ResultsOutputFile)
 	}
 
-	os.Exit(status)
+	return err
 }

--- a/pkg/results/data_results.go
+++ b/pkg/results/data_results.go
@@ -571,10 +571,9 @@ func ExitData(
 	counterStorage *storage.CounterStorage,
 	balanceStorage *storage.BalanceStorage,
 	err error,
-	status int,
 	endCondition configuration.CheckDataEndCondition,
 	endConditionDetail string,
-) {
+) error {
 	results := ComputeCheckDataResults(
 		config,
 		err,
@@ -588,5 +587,5 @@ func ExitData(
 		results.Output(config.Data.ResultsOutputFile)
 	}
 
-	os.Exit(status)
+	return err
 }

--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/coinbase/rosetta-cli/configuration"
@@ -486,15 +485,18 @@ func (t *ConstructionTester) returnFunds(
 func (t *ConstructionTester) HandleErr(
 	err error,
 	sigListeners *[]context.CancelFunc,
-) {
+) error {
 	if *t.signalReceived {
-		color.Red("Check halted")
-		os.Exit(1)
-		return
+		return results.ExitConstruction(
+			t.config,
+			t.counterStorage,
+			t.jobStorage,
+			errors.New("check halted"),
+		)
 	}
 
 	if !t.reachedEndConditions {
-		results.ExitConstruction(t.config, t.counterStorage, t.jobStorage, err, 1)
+		return results.ExitConstruction(t.config, t.counterStorage, t.jobStorage, err)
 	}
 
 	// We optimistically run the ReturnFunds function on the coordinator
@@ -505,5 +507,5 @@ func (t *ConstructionTester) HandleErr(
 		sigListeners,
 	)
 
-	results.ExitConstruction(t.config, t.counterStorage, t.jobStorage, nil, 0)
+	return results.ExitConstruction(t.config, t.counterStorage, t.jobStorage, nil)
 }


### PR DESCRIPTION
Relates: #145 

This PR changes all commands to use `RunE` so that `cobra` can invoke a post process function. This also contains some minor cleanups enabled by using `RunE` instead of exiting manually from each command.