### PR TITLE
Prepare for v0.5.7 release

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,7 +67,7 @@ func rootPreRun(*cobra.Command, []string) error {
 
 	f, err := os.Create(cpuProfile)
 	if err != nil {
-		return fmt.Errorf("unable to create CPU profile file: %v", err)
+		return fmt.Errorf("%w: unable to create CPU profile file", err)
 	}
 	if err := pprof.StartCPUProfile(f); err != nil {
 		if err := f.Close(); err != nil {
@@ -101,6 +101,7 @@ func rootPostRun() {
 		log.Printf("error while creating mem-profile file: %v", err)
 		return
 	}
+
 	defer func() {
 		if err := f.Close(); err != nil {
 			log.Printf("error while closing mem-profile file: %v", err)
@@ -212,6 +213,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.5.6")
+		fmt.Println("v0.5.7")
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.4.8
+	github.com/coinbase/rosetta-sdk-go v0.4.9
 	github.com/fatih/color v1.9.0
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/coinbase/rosetta-sdk-go v0.4.7 h1:5KFc0CgLMkKamX++hYUFvE58a5/tCn0wSqp
 github.com/coinbase/rosetta-sdk-go v0.4.7/go.mod h1:8d4iN4VSGvLUzl+jRQlvYSLyS9TeY0QZebneWouizqU=
 github.com/coinbase/rosetta-sdk-go v0.4.8 h1:+E1TM4q1c5/x/jE9FPI1IZIbNvUWy4tRRgDPLnKzUV4=
 github.com/coinbase/rosetta-sdk-go v0.4.8/go.mod h1:8d4iN4VSGvLUzl+jRQlvYSLyS9TeY0QZebneWouizqU=
+github.com/coinbase/rosetta-sdk-go v0.4.9 h1:Agy5+jrREo4Fa/0Jl0KEOvJDUxaImuCMD0qOxGiUwb4=
+github.com/coinbase/rosetta-sdk-go v0.4.9/go.mod h1:8d4iN4VSGvLUzl+jRQlvYSLyS9TeY0QZebneWouizqU=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=


### PR DESCRIPTION
Fixes: #138 

This PR prepares `rosetta-cli` for `v0.5.7` release.