### PR TITLE
Fix printing of reconciliation coverage percentage

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -104,7 +104,7 @@ func (l *Logger) LogDataStatus(ctx context.Context, status *results.CheckDataSta
 		status.Stats.Operations,
 		status.Stats.ActiveReconciliations+status.Stats.InactiveReconciliations,
 		status.Stats.InactiveReconciliations,
-		status.Stats.ReconciliationCoverage,
+		status.Stats.ReconciliationCoverage * 100,
 	)
 
 	// Don't print out the same stats message twice.

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -104,7 +104,7 @@ func (l *Logger) LogDataStatus(ctx context.Context, status *results.CheckDataSta
 		status.Stats.Operations,
 		status.Stats.ActiveReconciliations+status.Stats.InactiveReconciliations,
 		status.Stats.InactiveReconciliations,
-		status.Stats.ReconciliationCoverage * 100,
+		status.Stats.ReconciliationCoverage*utils.OneHundred,
 	)
 
 	// Don't print out the same stats message twice.


### PR DESCRIPTION
Reconciliation logs were being printed as e.g. `Coverage: 0.550958%` rather than `Coverage: 55.0958%`.

There might be other instances of percentages not being adjusted properly; I didn't investigate too deeply.