### PR TITLE
[BUG] Reconciliation Coverage End Condition Panic

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -217,6 +217,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.5.8")
+		fmt.Println("v0.5.9")
 	},
 }

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -172,7 +172,7 @@ type ReconciliationCoverage struct {
 
 	// Index is an int64 indicating the height that must be
 	// reached before reconciliation coverage is considered valid.
-	Index *int64 `json:"height,omitempty"`
+	Index *int64 `json:"index,omitempty"`
 
 	// AccountCount is an int64 indicating the number of accounts
 	// that must be observed before reconciliation coverage is considered

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -470,7 +470,6 @@ func (t *DataTester) EndReconciliationCoverage( // nolint:gocognit
 			}
 
 			// Check if at required minimum index
-			// TODO: blockIdentifer is nil if not at tip
 			if reconciliationCoverage.Index != nil && *reconciliationCoverage.Index < blockIdentifier.Index {
 				continue
 			}

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -436,7 +436,10 @@ func (t *DataTester) EndReconciliationCoverage( // nolint:gocognit
 			return
 
 		case <-tc.C:
-			atTip, blockIdentifier, err := t.blockStorage.AtTip(ctx, t.config.TipDelay)
+			headBlock, err := t.blockStorage.GetBlock(ctx, nil)
+			if errors.Is(err, storage.ErrHeadBlockNotFound) {
+				continue
+			}
 			if err != nil {
 				log.Printf(
 					"%s: unable to evaluate syncer height or if at tip",
@@ -445,7 +448,10 @@ func (t *DataTester) EndReconciliationCoverage( // nolint:gocognit
 				continue
 			}
 
-			// Only check coverage if we are at tip.
+			blockIdentifier := headBlock.BlockIdentifier
+			atTip := utils.AtTip(t.config.TipDelay, headBlock.Timestamp)
+
+			// Check if we are at tip and set tip height if fromTip is true.
 			if reconciliationCoverage.Tip || reconciliationCoverage.FromTip {
 				// If we fall behind tip, we must reset the firstTipIndex.
 				if !atTip {
@@ -464,6 +470,7 @@ func (t *DataTester) EndReconciliationCoverage( // nolint:gocognit
 			}
 
 			// Check if at required minimum index
+			// TODO: blockIdentifer is nil if not at tip
 			if reconciliationCoverage.Index != nil && *reconciliationCoverage.Index < blockIdentifier.Index {
 				continue
 			}


### PR DESCRIPTION
Fixes #156 

This PR fixes a panic when running `end_conditions` with a minimum `index` for `reconciliation_coverage`.

### Changes
- [x] use `GetBlock` to ensure returned block is always populated (only populated in `AtTip` when at tip)
- [x] fix `configuration` to use `index` instead of `height`
- [x] update version to `v0.5.9`