### PR TITLE
[BUG] Call online node for construction metadata

### DIFF
--- a/pkg/processor/coordinator_helper.go
+++ b/pkg/processor/coordinator_helper.go
@@ -204,7 +204,7 @@ func (c *CoordinatorHelper) Metadata(
 		arg{argMetadata, metadataRequest},
 		arg{argPublicKeys, publicKeys},
 	)
-	metadata, suggestedFee, fetchErr := c.offlineFetcher.ConstructionMetadata(
+	metadata, suggestedFee, fetchErr := c.onlineFetcher.ConstructionMetadata(
 		ctx,
 		networkIdentifier,
 		metadataRequest,


### PR DESCRIPTION
Fixes #158.

### Motivation
The Construction API spec [here](https://www.rosetta-api.org/docs/construction_api_introduction.html#completely-offline) states that we can use the `/construction/metadata` endpoint to fetch dynamic information (such as account nonce). Therefore, I believe that we should request the metadata from the online node.

### Solution
Use the CoordinatorHelper's `onlineFetcher` instead of `offlineFetcher` for `CoordinatorHelper.Metadata`.
