### PR TITLE
Prepare for v0.5.11 release

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -217,6 +217,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.5.10")
+		fmt.Println("v0.5.11")
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.2-0.20201006190307-bf4606611446
+	github.com/coinbase/rosetta-sdk-go v0.5.2
 	github.com/fatih/color v1.9.0
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/coinbase/rosetta-sdk-go v0.5.1 h1:UGuEt/nMWHvnLmWZqJdoQP+HhWL5/6K04rj
 github.com/coinbase/rosetta-sdk-go v0.5.1/go.mod h1:QVVeKHWFNb0NyzEY06LxXMAylJkYa7n+Hk03pORr0ws=
 github.com/coinbase/rosetta-sdk-go v0.5.2-0.20201006190307-bf4606611446 h1:KbefWZdPOb0yBl5DGV/FfJ95OJMiHxdxiJGLY+EjlT0=
 github.com/coinbase/rosetta-sdk-go v0.5.2-0.20201006190307-bf4606611446/go.mod h1:QVVeKHWFNb0NyzEY06LxXMAylJkYa7n+Hk03pORr0ws=
+github.com/coinbase/rosetta-sdk-go v0.5.2 h1:G91QWW0wrqmMhW2vJ4LP9P3gVukZs7df2Gf6FF1uff0=
+github.com/coinbase/rosetta-sdk-go v0.5.2/go.mod h1:QVVeKHWFNb0NyzEY06LxXMAylJkYa7n+Hk03pORr0ws=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -404,27 +404,27 @@ func (l *Logger) ReconcileFailureStream(
 	account *types.AccountIdentifier,
 	currency *types.Currency,
 	computedBalance string,
-	nodeBalance string,
+	liveBalance string,
 	block *types.BlockIdentifier,
 ) error {
 	// Always print out reconciliation failures
 	if reconciliationType == reconciler.InactiveReconciliation {
 		color.Yellow(
-			"Missing balance-changing operation detected for %s computed balance: %s%s node balance: %s%s",
+			"Missing balance-changing operation detected for %s computed: %s%s live: %s%s",
 			types.AccountString(account),
 			computedBalance,
 			currency.Symbol,
-			nodeBalance,
+			liveBalance,
 			currency.Symbol,
 		)
 	} else {
 		color.Yellow(
-			"Reconciliation failed for %s at %d computed: %s%s node: %s%s",
+			"Reconciliation failed for %s at %d computed: %s%s live: %s%s",
 			types.AccountString(account),
 			block.Index,
 			computedBalance,
 			currency.Symbol,
-			nodeBalance,
+			liveBalance,
 			currency.Symbol,
 		)
 	}
@@ -445,14 +445,14 @@ func (l *Logger) ReconcileFailureStream(
 	defer closeFile(f)
 
 	_, err = f.WriteString(fmt.Sprintf(
-		"Type:%s Account: %s Currency: %s Block: %s:%d computed: %s node: %s\n",
+		"Type:%s Account: %s Currency: %s Block: %s:%d computed: %s live: %s\n",
 		reconciliationType,
 		types.AccountString(account),
 		types.CurrencyString(currency),
 		block.Hash,
 		block.Index,
 		computedBalance,
-		nodeBalance,
+		liveBalance,
 	))
 	if err != nil {
 		return err

--- a/pkg/processor/reconciler_handler.go
+++ b/pkg/processor/reconciler_handler.go
@@ -66,7 +66,7 @@ func (h *ReconcilerHandler) ReconciliationFailed(
 	account *types.AccountIdentifier,
 	currency *types.Currency,
 	computedBalance string,
-	nodeBalance string,
+	liveBalance string,
 	block *types.BlockIdentifier,
 ) error {
 	err := h.logger.ReconcileFailureStream(
@@ -75,7 +75,7 @@ func (h *ReconcilerHandler) ReconciliationFailed(
 		account,
 		currency,
 		computedBalance,
-		nodeBalance,
+		liveBalance,
 		block,
 	)
 	if err != nil {
@@ -98,7 +98,7 @@ func (h *ReconcilerHandler) ReconciliationFailed(
 				block.Index,
 				computedBalance,
 				currency.Symbol,
-				nodeBalance,
+				liveBalance,
 				currency.Symbol,
 			)
 		}
@@ -112,7 +112,7 @@ func (h *ReconcilerHandler) ReconciliationFailed(
 			block.Index,
 			computedBalance,
 			currency.Symbol,
-			nodeBalance,
+			liveBalance,
 			currency.Symbol,
 		)
 	}
@@ -128,7 +128,7 @@ func (h *ReconcilerHandler) ReconciliationExempt(
 	account *types.AccountIdentifier,
 	currency *types.Currency,
 	computedBalance string,
-	nodeBalance string,
+	liveBalance string,
 	block *types.BlockIdentifier,
 	exemption *types.BalanceExemption,
 ) error {


### PR DESCRIPTION
This PR prepares for `rosetta-cli@v0.5.11`.

### Changes
- [x] Update to [`rosetta-sdk-go@v0.5.2`](https://github.com/coinbase/rosetta-sdk-go/releases/tag/v0.5.2)
- [x] Update version to `v0.5.11`
- [x] Ensure reconciliation failure logs are consistent