### PR TITLE
[reconciler] Use buffered channels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.2
+	github.com/coinbase/rosetta-sdk-go v0.5.3-0.20201015002757-978c228143a3
 	github.com/fatih/color v1.9.0
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/coinbase/rosetta-sdk-go v0.5.2-0.20201006190307-bf4606611446 h1:KbefW
 github.com/coinbase/rosetta-sdk-go v0.5.2-0.20201006190307-bf4606611446/go.mod h1:QVVeKHWFNb0NyzEY06LxXMAylJkYa7n+Hk03pORr0ws=
 github.com/coinbase/rosetta-sdk-go v0.5.2 h1:G91QWW0wrqmMhW2vJ4LP9P3gVukZs7df2Gf6FF1uff0=
 github.com/coinbase/rosetta-sdk-go v0.5.2/go.mod h1:QVVeKHWFNb0NyzEY06LxXMAylJkYa7n+Hk03pORr0ws=
+github.com/coinbase/rosetta-sdk-go v0.5.3-0.20201015002757-978c228143a3 h1:p8p0dVZDh/Zs35tzQq3nFftgFbphNvSzZ6dzLT31F7I=
+github.com/coinbase/rosetta-sdk-go v0.5.3-0.20201015002757-978c228143a3/go.mod h1:QVVeKHWFNb0NyzEY06LxXMAylJkYa7n+Hk03pORr0ws=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -469,8 +469,27 @@ func (t *DataTester) EndReconciliationCoverage( // nolint:gocognit
 				}
 			}
 
+			// minIndex is the greater of firstTipIndex
+			// and reconciliationCoverage.Index
+			minIndex := firstTipIndex
+
 			// Check if at required minimum index
-			if reconciliationCoverage.Index != nil && *reconciliationCoverage.Index < blockIdentifier.Index {
+			if reconciliationCoverage.Index != nil {
+				if *reconciliationCoverage.Index < blockIdentifier.Index {
+					continue
+				}
+
+				// Override the firstTipIndex if reconciliationCoverage.Index
+				// is greater
+				if *reconciliationCoverage.Index > minIndex {
+					minIndex = *reconciliationCoverage.Index
+				}
+			}
+
+			// Check if all accounts reconciled at index (+1). If last index reconciled
+			// is less than the minimum allowed index but the QueueSize is 0, then
+			// we consider the reconciler to be caught up.
+			if t.reconciler.LastIndexReconciled() <= minIndex && t.reconciler.QueueSize() > 0 {
 				continue
 			}
 


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-sdk-go/pull/187

This PR changes the `rosetta-cli` to use buffered channels for the reconciler.

### Changes
- [x] update rosetta-sdk-go
- [x] only exit reconciliation coverage end condition if last index is greater than min (protects against buffered channel backlog)