### PR TITLE
[Logging] Expose Reconciler Queue Size + Last Checked

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -247,6 +247,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.5.12")
+		fmt.Println("v0.5.13")
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.3-0.20201015002757-978c228143a3
+	github.com/coinbase/rosetta-sdk-go v0.5.3
 	github.com/fatih/color v1.9.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/coinbase/rosetta-sdk-go v0.5.3-0.20201015002757-978c228143a3 h1:p8p0dVZDh/Zs35tzQq3nFftgFbphNvSzZ6dzLT31F7I=
 github.com/coinbase/rosetta-sdk-go v0.5.3-0.20201015002757-978c228143a3/go.mod h1:QVVeKHWFNb0NyzEY06LxXMAylJkYa7n+Hk03pORr0ws=
+github.com/coinbase/rosetta-sdk-go v0.5.3 h1:AujxZ2VDbq80x7SJDHd1nKOYA8AFD5H27gx07uerFpw=
+github.com/coinbase/rosetta-sdk-go v0.5.3/go.mod h1:QVVeKHWFNb0NyzEY06LxXMAylJkYa7n+Hk03pORr0ws=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -122,12 +122,14 @@ func (l *Logger) LogDataStatus(ctx context.Context, status *results.CheckDataSta
 	}
 
 	progressMessage := fmt.Sprintf(
-		"[PROGRESS] Blocks Synced: %d/%d (Completed: %f%%, Rate: %f/second) Time Remaining: %s",
+		"[PROGRESS] Blocks Synced: %d/%d (Completed: %f%%, Rate: %f/second) Time Remaining: %s Reconciler Queue: %d (Last Index Checked: %d)",
 		status.Progress.Blocks,
 		status.Progress.Tip,
 		status.Progress.Completed,
 		status.Progress.Rate,
 		status.Progress.TimeRemaining,
+		status.Progress.ReconcilerQueueSize,
+		status.Progress.ReconcilerLastIndex,
 	)
 
 	// Don't print out the same progress message twice.

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -122,7 +122,7 @@ func (l *Logger) LogDataStatus(ctx context.Context, status *results.CheckDataSta
 	}
 
 	progressMessage := fmt.Sprintf(
-		"[PROGRESS] Blocks Synced: %d/%d (Completed: %f%%, Rate: %f/second) Time Remaining: %s Reconciler Queue: %d (Last Index Checked: %d)",
+		"[PROGRESS] Blocks Synced: %d/%d (Completed: %f%%, Rate: %f/second) Time Remaining: %s Reconciler Queue: %d (Last Index Checked: %d)", // nolint:lll
 		status.Progress.Blocks,
 		status.Progress.Tip,
 		status.Progress.Completed,

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -361,7 +361,14 @@ func (t *DataTester) StartPeriodicLogger(
 				big.NewInt(periodicLoggingSeconds),
 			)
 
-			status := results.ComputeCheckDataStatus(ctx, t.counterStorage, t.balanceStorage, t.fetcher, t.config.Network)
+			status := results.ComputeCheckDataStatus(
+				ctx,
+				t.counterStorage,
+				t.balanceStorage,
+				t.fetcher,
+				t.config.Network,
+				t.reconciler,
+			)
 			t.logger.LogDataStatus(ctx, status)
 		}
 	}
@@ -378,6 +385,7 @@ func (t *DataTester) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		t.balanceStorage,
 		t.fetcher,
 		t.network,
+		t.reconciler,
 	)
 
 	if err := json.NewEncoder(w).Encode(status); err != nil {


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-sdk-go/pull/187

This PR exposes new reconciler information (`QueueSize` and `LastIndexReconciled`) in the `check:data` status endpoint.

### Changes
- [x] Update `rosetta-cli` version
- [x] Add logging changes
- [x] Update to new `rosetta-sdk-go` release