### PR TITLE
[Reconciler] Reconcile Pruned Blocks

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -247,6 +247,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.5.13")
+		fmt.Println("v0.5.14")
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.4
+	github.com/coinbase/rosetta-sdk-go v0.5.5
 	github.com/fatih/color v1.9.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.9.22 h1:/Fea9n2EWJuNJ9oahMq9luqjRBcbW7QWdThbcJl13ek=
 github.com/ethereum/go-ethereum v1.9.22/go.mod h1:FQjK3ZwD8C5DYn7ukTmFee36rq1dOMESiUfXr5RUc1w=
+github.com/ethereum/go-ethereum v1.9.23 h1:SIKhg/z4Q7AbvqcxuPYvMxf36che/Rq/Pp0IdYEkbtw=
 github.com/ethereum/go-ethereum v1.9.23/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/coinbase/rosetta-sdk-go v0.5.4-0.20201015182847-250f7d0adf51 h1:hcSMD
 github.com/coinbase/rosetta-sdk-go v0.5.4-0.20201015182847-250f7d0adf51/go.mod h1:QVVeKHWFNb0NyzEY06LxXMAylJkYa7n+Hk03pORr0ws=
 github.com/coinbase/rosetta-sdk-go v0.5.4 h1:pM18LK2ci8zZwIu+uETmP6BXHqZbQGXRulwQCjYudg4=
 github.com/coinbase/rosetta-sdk-go v0.5.4/go.mod h1:QVVeKHWFNb0NyzEY06LxXMAylJkYa7n+Hk03pORr0ws=
+github.com/coinbase/rosetta-sdk-go v0.5.5 h1:Z61/VUO89BDVl1m6Zj0e6OWMl5GnVevj4z79Eh3sSL0=
+github.com/coinbase/rosetta-sdk-go v0.5.5/go.mod h1:JRO4BJjhWAI7nYGwzYZWFgYfCTsQOvdZB7tGyN6kEtE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -133,6 +135,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.9.22 h1:/Fea9n2EWJuNJ9oahMq9luqjRBcbW7QWdThbcJl13ek=
 github.com/ethereum/go-ethereum v1.9.22/go.mod h1:FQjK3ZwD8C5DYn7ukTmFee36rq1dOMESiUfXr5RUc1w=
+github.com/ethereum/go-ethereum v1.9.23/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=

--- a/pkg/processor/reconciler_helper.go
+++ b/pkg/processor/reconciler_helper.go
@@ -16,7 +16,6 @@ package processor
 
 import (
 	"context"
-	"errors"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/reconciler"
@@ -52,24 +51,15 @@ func NewReconcilerHelper(
 	}
 }
 
-// BlockExists returns a boolean indicating if block_storage
-// contains a block. This is necessary to reconcile across
+// CanonicalBlock returns a boolean indicating if a block
+// is in the canonical chain. This is necessary to reconcile across
 // reorgs. If the block returned on an account balance fetch
 // does not exist, reconciliation will be skipped.
-func (h *ReconcilerHelper) BlockExists(
+func (h *ReconcilerHelper) CanonicalBlock(
 	ctx context.Context,
 	block *types.BlockIdentifier,
 ) (bool, error) {
-	_, err := h.blockStorage.GetBlock(ctx, types.ConstructPartialBlockIdentifier(block))
-	if err == nil {
-		return true, nil
-	}
-
-	if errors.Is(err, storage.ErrBlockNotFound) {
-		return false, nil
-	}
-
-	return false, err
+	return h.blockStorage.CanonicalBlock(ctx, block)
 }
 
 // CurrentBlock returns the last processed block and is used

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -343,12 +343,11 @@ func (t *DataTester) PruneableIndex(
 	ctx context.Context,
 	headIndex int64,
 ) (int64, error) {
-	if t.config.Data.ReconciliationDisabled {
-		// It is ok if the returned value here is negative
-		return headIndex - statefulsyncer.DefaultPruningDepth, nil
-	}
-
-	return t.reconciler.LastIndexReconciled() - 1, nil
+	// We don't need blocks to exist to reconcile
+	// balances at their index.
+	//
+	// It is ok if the returned value here is negative.
+	return headIndex - statefulsyncer.DefaultPruningDepth, nil
 }
 
 // StartReconciler starts the reconciler if


### PR DESCRIPTION
This enables `rosetta-cli` to prune blocks before balance changes from those blocks are reconciled.

### Changes
- [x] Update `rosetta-sdk-go@v0.5.5`
- [x] Cleanup `PruneableIndex`
- [x] Call new `storage.CanonicalBlock` method
- [x] update version