### PR TITLE
[check:data] Wait for reconciliation queue to drain

### DIFF
--- a/cmd/check_construction.go
+++ b/cmd/check_construction.go
@@ -157,6 +157,5 @@ func runCheckConstructionCmd(cmd *cobra.Command, args []string) error {
 	sigListeners := []context.CancelFunc{cancel}
 	go handleSignals(&sigListeners)
 
-	err = g.Wait()
-	return constructionTester.HandleErr(err, &sigListeners)
+	return constructionTester.HandleErr(g.Wait(), &sigListeners)
 }

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -158,13 +158,7 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) error {
 	sigListeners := []context.CancelFunc{cancel}
 	go handleSignals(&sigListeners)
 
-	err = g.Wait()
-
-	// Initialize new context because calling context
-	// will no longer be usable when after termination.
-	ctx = context.Background()
-
 	// HandleErr will exit if we should not attempt
 	// to find missing operations.
-	return dataTester.HandleErr(ctx, err, &sigListeners)
+	return dataTester.HandleErr(g.Wait(), &sigListeners)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -247,6 +247,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.5.14")
+		fmt.Println("v0.5.15")
 	},
 }

--- a/cmd/view_block.go
+++ b/cmd/view_block.go
@@ -98,7 +98,7 @@ func runViewBlockCmd(cmd *cobra.Command, args []string) error {
 
 	// Print out all balance changes in a given block. This does NOT exempt
 	// any operations/accounts from parsing.
-	p := parser.New(newFetcher.Asserter, func(*types.Operation) bool { return false })
+	p := parser.New(newFetcher.Asserter, func(*types.Operation) bool { return false }, nil)
 	changes, err := p.BalanceChanges(Context, block, false)
 	if err != nil {
 		return fmt.Errorf("%w: unable to calculate balance changes", err)

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -258,6 +258,11 @@ type DataConfiguration struct {
 	// some of the more advanced checks to confirm syncing is working as expected.
 	ReconciliationDisabled bool `json:"reconciliation_disabled"`
 
+	// ReconciliationDrainDisabled is a boolean that configures the rosetta-cli
+	// to exit check:data before the entire active reconciliation queue has
+	// been drained (if reconciliation is enabled).
+	ReconciliationDrainDisabled bool `json:"reconciliation_drain_disabled"`
+
 	// InactiveDiscrepencySearchDisabled is a boolean indicating if a search
 	// should be performed to find any inactive reconciliation discrepencies.
 	// Note, a search will never be performed if historical balance lookup

--- a/examples/configuration/default.json
+++ b/examples/configuration/default.json
@@ -28,6 +28,7 @@
   "bootstrap_balances": "",
   "interesting_accounts": "",
   "reconciliation_disabled": false,
+  "reconciliation_drain_disabled": false,
   "inactive_discrepency_search_disabled": false,
   "balance_tracking_disabled": false,
   "coin_tracking_disabled": false,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.5
+	github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020035250-cc90959e74b4
 	github.com/fatih/color v1.9.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020035250-cc90959e74b4
+	github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020173919-5019c40fa06c
 	github.com/fatih/color v1.9.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020173919-5019c40fa06c
+	github.com/coinbase/rosetta-sdk-go v0.5.6
 	github.com/fatih/color v1.9.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/coinbase/rosetta-sdk-go v0.5.5 h1:Z61/VUO89BDVl1m6Zj0e6OWMl5GnVevj4z79Eh3sSL0=
 github.com/coinbase/rosetta-sdk-go v0.5.5/go.mod h1:JRO4BJjhWAI7nYGwzYZWFgYfCTsQOvdZB7tGyN6kEtE=
+github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020035250-cc90959e74b4 h1:fVoxiqoTJyztkXGAxUqeguErNMrvPSpKt3WodMSB4tg=
+github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020035250-cc90959e74b4/go.mod h1:JRO4BJjhWAI7nYGwzYZWFgYfCTsQOvdZB7tGyN6kEtE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
-github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020173919-5019c40fa06c h1:5L1MQzPHgvj1aPscFj+KReRQLdoXfyP78xWkd9MEVqI=
-github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020173919-5019c40fa06c/go.mod h1:JRO4BJjhWAI7nYGwzYZWFgYfCTsQOvdZB7tGyN6kEtE=
+github.com/coinbase/rosetta-sdk-go v0.5.6 h1:mgSSw2NsVUBZPgeQegIWazJki0IT8Zd+xrFLS1afzJE=
+github.com/coinbase/rosetta-sdk-go v0.5.6/go.mod h1:JRO4BJjhWAI7nYGwzYZWFgYfCTsQOvdZB7tGyN6kEtE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -80,10 +80,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
-github.com/coinbase/rosetta-sdk-go v0.5.5 h1:Z61/VUO89BDVl1m6Zj0e6OWMl5GnVevj4z79Eh3sSL0=
-github.com/coinbase/rosetta-sdk-go v0.5.5/go.mod h1:JRO4BJjhWAI7nYGwzYZWFgYfCTsQOvdZB7tGyN6kEtE=
-github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020035250-cc90959e74b4 h1:fVoxiqoTJyztkXGAxUqeguErNMrvPSpKt3WodMSB4tg=
-github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020035250-cc90959e74b4/go.mod h1:JRO4BJjhWAI7nYGwzYZWFgYfCTsQOvdZB7tGyN6kEtE=
+github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020173919-5019c40fa06c h1:5L1MQzPHgvj1aPscFj+KReRQLdoXfyP78xWkd9MEVqI=
+github.com/coinbase/rosetta-sdk-go v0.5.6-0.20201020173919-5019c40fa06c/go.mod h1:JRO4BJjhWAI7nYGwzYZWFgYfCTsQOvdZB7tGyN6kEtE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -97,7 +97,7 @@ func (l *Logger) LogDataStatus(ctx context.Context, status *results.CheckDataSta
 	}
 
 	statsMessage := fmt.Sprintf(
-		"[STATS] Blocks: %d (Orphaned: %d) Transactions: %d Operations: %d Reconciliations: %d (Inactive: %d, Exempt: %d, Coverage: %f%%)", // nolint:lll
+		"[STATS] Blocks: %d (Orphaned: %d) Transactions: %d Operations: %d Reconciliations: %d (Inactive: %d, Exempt: %d, Skipped: %d, Coverage: %f%%)", // nolint:lll
 		status.Stats.Blocks,
 		status.Stats.Orphans,
 		status.Stats.Transactions,
@@ -105,6 +105,7 @@ func (l *Logger) LogDataStatus(ctx context.Context, status *results.CheckDataSta
 		status.Stats.ActiveReconciliations+status.Stats.InactiveReconciliations,
 		status.Stats.InactiveReconciliations,
 		status.Stats.ExemptReconciliations,
+		status.Stats.SkippedReconciliations,
 		status.Stats.ReconciliationCoverage*utils.OneHundred,
 	)
 

--- a/pkg/processor/balance_storage_helper.go
+++ b/pkg/processor/balance_storage_helper.go
@@ -38,6 +38,7 @@ type BalanceStorageHelper struct {
 	// Configuration settings
 	lookupBalanceByBlock bool
 	exemptAccounts       map[string]struct{}
+	balanceExemptions    []*types.BalanceExemption
 
 	// Interesting-only Parsing
 	interestingOnly      bool
@@ -51,6 +52,7 @@ func NewBalanceStorageHelper(
 	lookupBalanceByBlock bool,
 	exemptAccounts []*reconciler.AccountCurrency,
 	interestingOnly bool,
+	balanceExemptions []*types.BalanceExemption,
 ) *BalanceStorageHelper {
 	exemptMap := map[string]struct{}{}
 
@@ -67,6 +69,7 @@ func NewBalanceStorageHelper(
 		exemptAccounts:       exemptMap,
 		interestingAddresses: map[string]struct{}{},
 		interestingOnly:      interestingOnly,
+		balanceExemptions:    balanceExemptions,
 	}
 }
 
@@ -136,4 +139,9 @@ func (h *BalanceStorageHelper) ExemptFunc() parser.ExemptOperation {
 		_, exists := h.exemptAccounts[thisAcct]
 		return exists
 	}
+}
+
+// BalanceExemptions returns a list of *types.BalanceExemption.
+func (h *BalanceStorageHelper) BalanceExemptions() []*types.BalanceExemption {
+	return h.balanceExemptions
 }

--- a/pkg/processor/balance_storage_helper_test.go
+++ b/pkg/processor/balance_storage_helper_test.go
@@ -84,6 +84,7 @@ func TestExemptFuncExemptAccounts(t *testing.T) {
 				false,
 				test.exemptAccounts,
 				false,
+				nil,
 			)
 
 			result := helper.ExemptFunc()(&types.Operation{
@@ -125,6 +126,7 @@ func TestExemptFuncInterestingParsing(t *testing.T) {
 				false,
 				nil,
 				true,
+				nil,
 			)
 
 			for _, addr := range test.interestingAddresses {

--- a/pkg/processor/reconciler_handler.go
+++ b/pkg/processor/reconciler_handler.go
@@ -69,6 +69,8 @@ func (h *ReconcilerHandler) ReconciliationFailed(
 	liveBalance string,
 	block *types.BlockIdentifier,
 ) error {
+	_, _ = h.counterStorage.Update(ctx, storage.FailedReconciliationCounter, big.NewInt(1))
+
 	err := h.logger.ReconcileFailureStream(
 		ctx,
 		reconciliationType,

--- a/pkg/results/data_results.go
+++ b/pkg/results/data_results.go
@@ -531,7 +531,7 @@ func ReconciliationTest(
 }
 
 // ComputeCheckDataTests returns a populated CheckDataTests.
-func ComputeCheckDataTests(
+func ComputeCheckDataTests( // nolint:gocognit
 	ctx context.Context,
 	cfg *configuration.Configuration,
 	err error,

--- a/pkg/results/data_results.go
+++ b/pkg/results/data_results.go
@@ -494,9 +494,14 @@ func BalanceTrackingTest(cfg *configuration.Configuration, err error, operations
 // if no reconciliation errors were received.
 func ReconciliationTest(
 	cfg *configuration.Configuration,
+	err error,
 	reconciliationsPerformed bool,
 	reconciliationsFailed bool,
 ) *bool {
+	if errors.Is(err, ErrReconciliationFailure) {
+		return &f
+	}
+
 	if cfg.Data.BalanceTrackingDisabled ||
 		cfg.Data.ReconciliationDisabled ||
 		(!reconciliationsPerformed && !reconciliationsFailed) {
@@ -568,7 +573,7 @@ func ComputeCheckDataTests(
 		ResponseAssertion: ResponseAssertionTest(err),
 		BlockSyncing:      BlockSyncingTest(err, blocksSynced),
 		BalanceTracking:   BalanceTrackingTest(cfg, err, operationsSeen),
-		Reconciliation:    ReconciliationTest(cfg, reconciliationsPerformed, reconciliationsFailed),
+		Reconciliation:    ReconciliationTest(cfg, err, reconciliationsPerformed, reconciliationsFailed),
 	}
 }
 

--- a/pkg/results/data_results.go
+++ b/pkg/results/data_results.go
@@ -104,6 +104,7 @@ type CheckDataStats struct {
 	InactiveReconciliations int64   `json:"inactive_reconciliations"`
 	ExemptReconciliations   int64   `json:"exempt_reconciliations"`
 	FailedReconciliations   int64   `json:"failed_reconciliations"`
+	SkippedReconciliations  int64   `json:"skipped_reconciliations"`
 	ReconciliationCoverage  float64 `json:"reconciliation_coverage"`
 }
 
@@ -151,6 +152,13 @@ func (c *CheckDataStats) Print() {
 			"Failed Reconciliations",
 			"# of reconciliation failures",
 			strconv.FormatInt(c.FailedReconciliations, 10),
+		},
+	)
+	table.Append(
+		[]string{
+			"Skipped Reconciliations",
+			"# of reconciliations skipped",
+			strconv.FormatInt(c.SkippedReconciliations, 10),
 		},
 	)
 	table.Append(
@@ -222,6 +230,12 @@ func ComputeCheckDataStats(
 		return nil
 	}
 
+	skippedReconciliations, err := counters.Get(ctx, storage.SkippedReconciliationsCounter)
+	if err != nil {
+		log.Printf("%s: cannot get skipped reconciliations counter", err.Error())
+		return nil
+	}
+
 	stats := &CheckDataStats{
 		Blocks:                  blocks.Int64(),
 		Orphans:                 orphans.Int64(),
@@ -231,6 +245,7 @@ func ComputeCheckDataStats(
 		InactiveReconciliations: inactiveReconciliations.Int64(),
 		ExemptReconciliations:   exemptReconciliations.Int64(),
 		FailedReconciliations:   failedReconciliations.Int64(),
+		SkippedReconciliations:  skippedReconciliations.Int64(),
 	}
 
 	if balances != nil {

--- a/pkg/results/data_results_test.go
+++ b/pkg/results/data_results_test.go
@@ -33,11 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	tr = true
-	f  = false
-)
-
 func TestComputeCheckDataResults(t *testing.T) {
 	var tests = map[string]struct {
 		cfg *configuration.Configuration

--- a/pkg/results/data_results_test.go
+++ b/pkg/results/data_results_test.go
@@ -43,6 +43,7 @@ func TestComputeCheckDataResults(t *testing.T) {
 		operationCount          int64
 		activeReconciliations   int64
 		inactiveReconciliations int64
+		reconciliationFailures  int64
 
 		// balance storage values
 		provideBalanceStorage bool
@@ -298,6 +299,24 @@ func TestComputeCheckDataResults(t *testing.T) {
 				},
 			},
 		},
+		"default configuration, counter storage, reconciliation errors": {
+			cfg:                    configuration.DefaultConfiguration(),
+			err:                    []error{ErrReconciliationFailure},
+			provideCounterStorage:  true,
+			activeReconciliations:  10,
+			reconciliationFailures: 19,
+			result: &CheckDataResults{
+				Tests: &CheckDataTests{
+					RequestResponse:   true,
+					ResponseAssertion: true,
+					Reconciliation:    &f,
+				},
+				Stats: &CheckDataStats{
+					ActiveReconciliations: 10,
+					FailedReconciliations: 19,
+				},
+			},
+		},
 		"default configuration, no storage, unknown errors": {
 			cfg:    configuration.DefaultConfiguration(),
 			err:    []error{errors.New("unsure how to handle this error")},
@@ -376,6 +395,13 @@ func TestComputeCheckDataResults(t *testing.T) {
 						ctx,
 						storage.InactiveReconciliationCounter,
 						big.NewInt(test.inactiveReconciliations),
+					)
+					assert.NoError(t, err)
+
+					_, err = counterStorage.Update(
+						ctx,
+						storage.FailedReconciliationCounter,
+						big.NewInt(test.reconciliationFailures),
 					)
 					assert.NoError(t, err)
 				}

--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -97,6 +97,11 @@ func InitializeConstruction(
 		log.Fatalf("%s: unable to initialize database", err.Error())
 	}
 
+	networkOptions, fetchErr := onlineFetcher.NetworkOptionsRetry(ctx, network, nil)
+	if err != nil {
+		log.Fatalf("%s: unable to get network options", fetchErr.Err.Error())
+	}
+
 	counterStorage := storage.NewCounterStorage(localStore)
 	logger := logger.NewLogger(
 		dataPath,
@@ -118,6 +123,7 @@ func InitializeConstruction(
 		false,
 		nil,
 		true,
+		networkOptions.Allow.BalanceExemptions,
 	)
 
 	balanceStorageHandler := processor.NewBalanceStorageHandler(
@@ -138,7 +144,7 @@ func InitializeConstruction(
 		config.Construction.BlockBroadcastLimit,
 	)
 
-	parser := parser.New(onlineFetcher.Asserter, nil)
+	parser := parser.New(onlineFetcher.Asserter, nil, networkOptions.Allow.BalanceExemptions)
 	broadcastHelper := processor.NewBroadcastStorageHelper(
 		blockStorage,
 		onlineFetcher,

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -688,7 +688,11 @@ func (t *DataTester) DrainReconcilerQueue(ctx context.Context, sigListeners *[]c
 // HandleErr is called when `check:data` returns an error.
 // If historical balance lookups are enabled, HandleErr will attempt to
 // automatically find any missing balance-changing operations.
-func (t *DataTester) HandleErr(ctx context.Context, err error, sigListeners *[]context.CancelFunc) error {
+func (t *DataTester) HandleErr(err error, sigListeners *[]context.CancelFunc) error {
+	// Initialize new context because calling context
+	// will no longer be usable when after termination.
+	ctx := context.Background()
+
 	if *t.signalReceived {
 		return results.ExitData(
 			t.config,

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -180,7 +180,8 @@ func InitializeData(
 	// until rosetta-cli restart.
 	if len(config.Data.BootstrapBalances) > 0 {
 		_, err := blockStorage.GetHeadBlockIdentifier(ctx)
-		if err == storage.ErrHeadBlockNotFound {
+		switch {
+		case err == storage.ErrHeadBlockNotFound:
 			err = balanceStorage.BootstrapBalances(
 				ctx,
 				config.Data.BootstrapBalances,
@@ -189,7 +190,9 @@ func InitializeData(
 			if err != nil {
 				log.Fatalf("%s: unable to bootstrap balances", err.Error())
 			}
-		} else {
+		case err != nil:
+			log.Fatalf("%s: unable to get head block identifier", err.Error())
+		default:
 			log.Println("Skipping balance bootstrapping because already started syncing")
 		}
 	}


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-sdk-go/pull/196
Related: https://github.com/coinbase/rosetta-sdk-go/pull/200

This PR prevents `rosetta-cli` from exiting until the entire reconciler backlog has been drained (can optionally disable). As a result, it is now possible to reach 100% reconciliation coverage.

### Changes
- [x] Update version
- [x] Add `ReconciliationDrainDisabled` to configure the `rosetta-cli` to exit before draining the backlog
- [x] Update to `rosetta-sdk-go@v0.5.6`
- [x] If `ReconciliationDrainDisabled` is false, wait for reconciliation queue to exit before draining
- [x] Ensure balances are bootstrapped before initializing reconciler