### PR TITLE
Retry 502, 503, and 504 HTTP Codes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -257,6 +257,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.5.22")
+		fmt.Println("v0.5.23")
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.10
+	github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201106052603-0322f7b18be8
 	github.com/fatih/color v1.10.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/coinbase/rosetta-sdk-go v0.5.10 h1:lXXlaxshpAWgp85TpBr8pdAL/mcvUjce2qt231yBIIg=
 github.com/coinbase/rosetta-sdk-go v0.5.10/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
+github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201106052603-0322f7b18be8 h1:rIPzKk6a2adG0VqC5Rh0fipPlQbaf41yiKRriAIT3gc=
+github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201106052603-0322f7b18be8/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-sdk-go/pull/230

In some cases, intermediate services will return a 502, 503, or 504 HTTP status code before making a request to a Rosetta implementation. This can cause clients to error hard instead of retrying gracefully. This PR ensures we treat these errors as retriable.

### Changes
- [x] update rosetta-sdk-go
- [x] update version