### PR TITLE
[chore] `rosetta-specifications@v1.4.8` Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Available Commands:
   utils:asserter-configuration Generate a static configuration file for the Asserter
   utils:train-zstd             Generate a zstd dictionary for enhanced compression performance
   version                      Print rosetta-cli version
-  view:account                 View an account balance
+  view:balance                 View an account balance
   view:block                   View a block
   view:networks                View all network statuses
 
@@ -397,22 +397,22 @@ Global Flags:
       --mem-profile string          Save the pprof mem profile in the specified file
 ```
 
-#### view:account
+#### view:balance
 ```
 While debugging, it is often useful to inspect the state
 of an account at a certain block. This command allows you to look up
 any account by providing a JSON representation of a types.AccountIdentifier
 (and optionally a height to perform the query).
 
-For example, you could run view:account '{"address":"interesting address"}' 1000
+For example, you could run view:balance '{"address":"interesting address"}' 1000
 to lookup the balance of an interesting address at block 1000. Allowing the
 address to specified as JSON allows for querying by SubAccountIdentifier.
 
 Usage:
-  rosetta-cli view:account [flags]
+  rosetta-cli view:balance [flags]
 
 Flags:
-  -h, --help   help for view:account
+  -h, --help   help for view:balance
 
 Global Flags:
       --block-profile string        Save the pprof block profile in the specified file

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -257,6 +257,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.5.23")
+		fmt.Println("v0.6.0")
 	},
 }

--- a/cmd/view_balance.go
+++ b/cmd/view_balance.go
@@ -30,22 +30,22 @@ import (
 
 var (
 	viewAccountCmd = &cobra.Command{
-		Use:   "view:account",
+		Use:   "view:balance",
 		Short: "View an account balance",
 		Long: `While debugging, it is often useful to inspect the state
 of an account at a certain block. This command allows you to look up
 any account by providing a JSON representation of a types.AccountIdentifier
 (and optionally a height to perform the query).
 
-For example, you could run view:account '{"address":"interesting address"}' 1000
+For example, you could run view:balance '{"address":"interesting address"}' 1000
 to lookup the balance of an interesting address at block 1000. Allowing the
 address to specified as JSON allows for querying by SubAccountIdentifier.`,
-		RunE: runViewAccountCmd,
+		RunE: runViewBalanceCmd,
 		Args: cobra.MinimumNArgs(1),
 	}
 )
 
-func runViewAccountCmd(cmd *cobra.Command, args []string) error {
+func runViewBalanceCmd(cmd *cobra.Command, args []string) error {
 	account := &types.AccountIdentifier{}
 	if err := json.Unmarshal([]byte(args[0]), account); err != nil {
 		return fmt.Errorf("%w: unable to unmarshal account %s", err, args[0])
@@ -84,18 +84,18 @@ func runViewAccountCmd(cmd *cobra.Command, args []string) error {
 		lookupBlock = &types.PartialBlockIdentifier{Index: &index}
 	}
 
-	block, amounts, coins, metadata, fetchErr := newFetcher.AccountBalanceRetry(
+	block, amounts, metadata, fetchErr := newFetcher.AccountBalanceRetry(
 		Context,
 		Config.Network,
 		account,
 		lookupBlock,
+		nil,
 	)
 	if fetchErr != nil {
 		return fmt.Errorf("%w: unable to fetch account %+v", fetchErr.Err, account)
 	}
 
 	log.Printf("Amounts: %s\n", types.PrettyPrintStruct(amounts))
-	log.Printf("Coins: %s\n", types.PrettyPrintStruct(coins))
 	log.Printf("Metadata: %s\n", types.PrettyPrintStruct(metadata))
 	log.Printf("Balance Fetched At: %s\n", types.PrettyPrintStruct(block))
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110050224-e6be00ef9da1
+	github.com/coinbase/rosetta-sdk-go v0.6.0
 	github.com/fatih/color v1.10.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110043432-d86a15694f49
+	github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110050224-e6be00ef9da1
 	github.com/fatih/color v1.10.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201106052603-0322f7b18be8
+	github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110043432-d86a15694f49
 	github.com/fatih/color v1.10.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/coinbase/rosetta-sdk-go v0.5.10 h1:lXXlaxshpAWgp85TpBr8pdAL/mcvUjce2q
 github.com/coinbase/rosetta-sdk-go v0.5.10/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
 github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201106052603-0322f7b18be8 h1:rIPzKk6a2adG0VqC5Rh0fipPlQbaf41yiKRriAIT3gc=
 github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201106052603-0322f7b18be8/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
+github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110043432-d86a15694f49 h1:fYkVRB7RqtesVO1azgT3s1RB4bDfmPlfCdmW+lFwb9A=
+github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110043432-d86a15694f49/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
-github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110050224-e6be00ef9da1 h1:CAceh+0T+53aGGsEf+AKJVxtIaU3pUhEqDN8HrnLXS4=
-github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110050224-e6be00ef9da1/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
+github.com/coinbase/rosetta-sdk-go v0.6.0 h1:U8/NhkPo7CGJR8Ud82Y0HqtujXSVzGZKscmxOHsmS54=
+github.com/coinbase/rosetta-sdk-go v0.6.0/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -76,12 +76,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
-github.com/coinbase/rosetta-sdk-go v0.5.10 h1:lXXlaxshpAWgp85TpBr8pdAL/mcvUjce2qt231yBIIg=
-github.com/coinbase/rosetta-sdk-go v0.5.10/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
-github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201106052603-0322f7b18be8 h1:rIPzKk6a2adG0VqC5Rh0fipPlQbaf41yiKRriAIT3gc=
-github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201106052603-0322f7b18be8/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
-github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110043432-d86a15694f49 h1:fYkVRB7RqtesVO1azgT3s1RB4bDfmPlfCdmW+lFwb9A=
-github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110043432-d86a15694f49/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
+github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110050224-e6be00ef9da1 h1:CAceh+0T+53aGGsEf+AKJVxtIaU3pUhEqDN8HrnLXS4=
+github.com/coinbase/rosetta-sdk-go v0.5.11-0.20201110050224-e6be00ef9da1/go.mod h1:pqBibzTcpz0mLqb7is8fo2qf93tcHjItJ3u7Yud8RI4=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -304,7 +304,7 @@ func (l *Logger) TransactionStream(
 				participant,
 				amount,
 				symbol,
-				op.Status,
+				*op.Status,
 			))
 			if err != nil {
 				return err

--- a/pkg/processor/balance_storage_helper.go
+++ b/pkg/processor/balance_storage_helper.go
@@ -96,7 +96,7 @@ func (h *BalanceStorageHelper) AccountBalance(
 	// In the case that we are syncing from arbitrary height,
 	// we may need to recover the balance of an account to
 	// perform validations.
-	amount, block, _, err := utils.CurrencyBalance(
+	amount, block, err := utils.CurrencyBalance(
 		ctx,
 		h.network,
 		h.fetcher,

--- a/pkg/processor/reconciler_helper.go
+++ b/pkg/processor/reconciler_helper.go
@@ -125,7 +125,7 @@ func (h *ReconcilerHelper) LiveBalance(
 	currency *types.Currency,
 	index int64,
 ) (*types.Amount, *types.BlockIdentifier, error) {
-	amt, block, _, err := utils.CurrencyBalance(
+	amt, block, err := utils.CurrencyBalance(
 		ctx,
 		h.network,
 		h.fetcher,


### PR DESCRIPTION
This PR updates `rosetta-cli` to use [`rosetta-specifications@v1.4.8`](https://github.com/coinbase/rosetta-specifications/releases/tag/v1.4.8). Notably, this adds support for ["indexer" endpoints](https://github.com/coinbase/rosetta-specifications#indexers)!

### Changes
- [x] `view:account` -> `view:balance`
- [x] update version
- [x] update to `rosetta-sdk-go@v0.6.0`