### PR TITLE
[pkg] Async Reconciler Count Updates

### DIFF
--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -143,6 +143,10 @@ func runCheckDataCmd(cmd *cobra.Command, args []string) error {
 	})
 
 	g.Go(func() error {
+		return dataTester.StartReconcilerCountUpdater(ctx)
+	})
+
+	g.Go(func() error {
 		return tester.LogMemoryLoop(ctx)
 	})
 

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -720,6 +720,12 @@ func (t *DataTester) WaitForEmptyQueue(
 			return ctx.Err()
 
 		case <-tc.C:
+			// We force cached counts to be written before
+			// determining if we should exit.
+			if err := t.reconcilerHandler.UpdateCounts(ctx); err != nil {
+				return err
+			}
+
 			nowComplete, err := t.CompleteReconciliations(ctx)
 			if err != nil {
 				return err

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -372,6 +372,14 @@ func (t *DataTester) StartPruning(
 	return t.syncer.Prune(ctx, t)
 }
 
+// StartReconcilerCountUpdater attempts to periodically
+// write cached reconciler count updates to storage.
+func (t *DataTester) StartReconcilerCountUpdater(
+	ctx context.Context,
+) error {
+	return t.reconcilerHandler.Updater(ctx)
+}
+
 // PruneableIndex is the index that is
 // safe for pruning.
 func (t *DataTester) PruneableIndex(


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-cli/tree/patrick/priority-locks

This PR updates `pkg/processor/reconciler_handler.go` to periodically persist counts to storage instead of synchronously. This can SUBSTANTIALLY increase the reconciliation rate.

### Changes
- [x] update `pkg/processor/reconciler_handler.go` to periodically persist cached counts to storage
- [x] invoke `Updater` and `UpdateCounts` in `cmd/check_data.go`