### PR TITLE
rosetta-sdk-go@v0.6.3

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -257,6 +257,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.6.1")
+		fmt.Println("v0.6.2")
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.6.2
+	github.com/coinbase/rosetta-sdk-go v0.6.3
 	github.com/fatih/color v1.10.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
-github.com/coinbase/rosetta-sdk-go v0.6.2 h1:vgynGMbRkYv8S3/swrLGlww1iOKfurILLRCGJOrtLMk=
-github.com/coinbase/rosetta-sdk-go v0.6.2/go.mod h1:MvQfsL2KlJ5786OdDviRIJE3agui2YcvS1CaQPDl1Yo=
+github.com/coinbase/rosetta-sdk-go v0.6.3 h1:PPj14tPJ7SFc8sY/hlwK8zddT7PKwWU2wicxyerDxlg=
+github.com/coinbase/rosetta-sdk-go v0.6.3/go.mod h1:MvQfsL2KlJ5786OdDviRIJE3agui2YcvS1CaQPDl1Yo=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -16,7 +16,7 @@
 
 VERSION=$1;
 
-xgo -go go-1.15.2 --targets=darwin/*,windows/*,linux/* -out "bin/rosetta-cli-${VERSION}" .;
+xgo -go go-1.15.5 --targets=darwin/*,windows/*,linux/* -out "bin/rosetta-cli-${VERSION}" .;
 
 # Rename some files
 mv "bin/rosetta-cli-${VERSION}-darwin-10.6-amd64" "bin/rosetta-cli-${VERSION}-darwin-amd64" 


### PR DESCRIPTION
This PR updates `rosetta-cli` to use the latest [`rosetta-sdk-go` release](https://github.com/coinbase/rosetta-sdk-go/releases/tag/v0.6.3).

### Changes
- [x] update `rosetta-sdk-go`
- [x] update version
- [x] increase go version used in compilation

### rosetta-sdk-go Changes
- [storage] Block Pruning Optimization [`#261`](https://github.com/coinbase/rosetta-sdk-go/pull/261)