### PR TITLE
Use configuration path provided by ROSETTA_CONFIGURATION_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ files for running tests against a Bitcoin Rosetta implementation
 ([config](https://github.com/coinbase/rosetta-bitcoin/tree/master/rosetta-cli-conf)) and an Ethereum Rosetta
 implementation ([config](https://github.com/coinbase/rosetta-ethereum/tree/master/rosetta-cli-conf)).
 
+#### Using environment variables
+
+It's possible to set the configuration file path using an environment variable instead
+of using a CLI flag. See an example below:
+
+```bash
+ROSETTA_CONFIGURATION_FILE=/path/to/cli/config rosetta <command>
+```
+
+CLI flags take precedence over environment variables.
+
 #### Writing check:construction Tests
 The new Construction API testing framework (first released in `rosetta-cli@v0.5.0`) uses
 a new design pattern to allow for complex transaction construction orchestration.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -215,6 +215,9 @@ func initConfig() {
 	Context = context.Background()
 	var err error
 	if len(configurationFile) == 0 {
+		configurationFile = os.Getenv("ROSETTA_CONFIGURATION_FILE")
+	}
+	if len(configurationFile) == 0 {
 		Config = configuration.DefaultConfiguration()
 	} else {
 		Config, err = configuration.LoadConfiguration(Context, configurationFile)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	// configEnvKey is an env variable name that sets a config file location
+	configEnvKey = "ROSETTA_CONFIGURATION_FILE"
+)
+
 var (
 	rootCmd = &cobra.Command{
 		Use:               "rosetta-cli",
@@ -214,9 +219,13 @@ default values.`,
 func initConfig() {
 	Context = context.Background()
 	var err error
+
+	// Use path provided by the environment variable if config path arg is not set.
+	// Default configuration will be used if the env var is not
 	if len(configurationFile) == 0 {
-		configurationFile = os.Getenv("ROSETTA_CONFIGURATION_FILE")
+		configurationFile = os.Getenv(configEnvKey)
 	}
+
 	if len(configurationFile) == 0 {
 		Config = configuration.DefaultConfiguration()
 	} else {


### PR DESCRIPTION
This change provides an option to specify the default config path with `ROSETTA_CONFIGURATION_FILE` environment variable if `--configuration-file` option is not provided. 

Improved use case looks like this:

```bash
export ROSETTA_CONFIGURATION_FILE=./path/to/my/config.json

$ rosetta-cli view:block XXX
$ rosetta-cli check:data
```