### PR TITLE
[chore] `rosetta-sdk-go@v0.6.4`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -257,6 +257,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.6.2")
+		fmt.Println("v0.6.3")
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.6.3
+	github.com/coinbase/rosetta-sdk-go v0.6.4
 	github.com/fatih/color v1.10.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
-github.com/coinbase/rosetta-sdk-go v0.6.3 h1:PPj14tPJ7SFc8sY/hlwK8zddT7PKwWU2wicxyerDxlg=
-github.com/coinbase/rosetta-sdk-go v0.6.3/go.mod h1:MvQfsL2KlJ5786OdDviRIJE3agui2YcvS1CaQPDl1Yo=
+github.com/coinbase/rosetta-sdk-go v0.6.4 h1:+3z6otziRDdgEwy7IsyTkwgCNbbH4z5QMDnXdbdg9ZY=
+github.com/coinbase/rosetta-sdk-go v0.6.4/go.mod h1:MvQfsL2KlJ5786OdDviRIJE3agui2YcvS1CaQPDl1Yo=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/processor/reconciler_helper.go
+++ b/pkg/processor/reconciler_helper.go
@@ -161,3 +161,18 @@ func (h *ReconcilerHelper) PruneBalances(
 		index,
 	)
 }
+
+// ForceInactiveReconciliation overrides the default
+// calculation to determine if an account should be
+// reconciled inactively.
+//
+// TODO: complete this implementation (forcing when
+// reaching tip if from_tip end condition is enabled)
+func (h *ReconcilerHelper) ForceInactiveReconciliation(
+	ctx context.Context,
+	account *types.AccountIdentifier,
+	currency *types.Currency,
+	lastChecked *types.BlockIdentifier,
+) bool {
+	return false
+}


### PR DESCRIPTION
This PR updates `rosetta-cli` to use the [latest `rosetta-sdk-go` release](base/rosetta-sdk-go/releases/tag/v0.6.4).

### Changes
- [x] Update `rosetta-cli` version
- [x] Add incomplete `ForceInactiveReconciler` implementation

#### `rosetta-sdk-go` Changes
- [database] Update BadgerDB Performance Settings [`#267`](https://github.com/coinbase/rosetta-sdk-go/pull/267)
- [reconciler] Inactive Reconciliation Bypass [`#264`](https://github.com/coinbase/rosetta-sdk-go/pull/264)
- [BUG][reconciler] Handle Skipped Reconciliations Correctly [`#266`](https://github.com/coinbase/rosetta-sdk-go/pull/266)
- [constructor/worker] Error if random range &lt; 0 [`#265`](https://github.com/coinbase/rosetta-sdk-go/pull/265)
- [client] Handle 408 Status Code as Retriable [`#263`](https://github.com/coinbase/rosetta-sdk-go/pull/263)

### Future Work
* Complete `ForceInactiveReconciler` implementation