### PR TITLE
[bug] Bootstrap Balances Panic

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -269,6 +269,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.6.3")
+		fmt.Println("v0.6.4")
 	},
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -232,6 +232,10 @@ func assertDataConfiguration(config *DataConfiguration) error {
 		return fmt.Errorf("start index %d cannot be negative", *config.StartIndex)
 	}
 
+	if !config.ReconciliationDisabled && config.BalanceTrackingDisabled {
+		return errors.New("balance tracking must be enabled to perform reconciliation")
+	}
+
 	if config.EndConditions == nil {
 		return nil
 	}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -240,7 +240,7 @@ func assertConstructionConfiguration(ctx context.Context, config *ConstructionCo
 	return nil
 }
 
-func assertDataConfiguration(config *DataConfiguration) error {
+func assertDataConfiguration(config *DataConfiguration) error { // nolint:gocognit
 	if config.StartIndex != nil && *config.StartIndex < 0 {
 		return fmt.Errorf("start index %d cannot be negative", *config.StartIndex)
 	}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -46,7 +46,6 @@ func DefaultDataConfiguration() *DataConfiguration {
 // EthereumNetwork, DefaultURL, DefaultTimeout,
 // DefaultConstructionConfiguration and DefaultDataConfiguration.
 func DefaultConfiguration() *Configuration {
-	numCPU := runtime.NumCPU()
 	return &Configuration{
 		Network:              EthereumNetwork,
 		OnlineURL:            DefaultURL,
@@ -57,8 +56,6 @@ func DefaultConfiguration() *Configuration {
 		TipDelay:             DefaultTipDelay,
 		MaxReorgDepth:        DefaultMaxReorgDepth,
 		Data:                 DefaultDataConfiguration(),
-		SeenBlockWorkers:     numCPU,
-		SerialBlockWorkers:   numCPU,
 	}
 }
 

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -68,6 +68,8 @@ var (
 		MaxSyncConcurrency:   12,
 		TipDelay:             1231,
 		MaxReorgDepth:        12,
+		SeenBlockWorkers:     300,
+		SerialBlockWorkers:   200,
 		Construction: &ConstructionConfiguration{
 			OfflineURL:            "https://ashdjaksdkjshdk",
 			MaxOfflineConnections: 21,

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os/exec"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/constructor/job"
@@ -158,7 +159,13 @@ func TestLoadConfiguration(t *testing.T) {
 	}{
 		"nothing provided": {
 			provided: &Configuration{},
-			expected: DefaultConfiguration(),
+			expected: func() *Configuration {
+				cfg := DefaultConfiguration()
+				cfg.SeenBlockWorkers = runtime.NumCPU()
+				cfg.SerialBlockWorkers = runtime.NumCPU()
+
+				return cfg
+			}(),
 		},
 		"no overwrite": {
 			provided: whackyConfig,
@@ -173,6 +180,8 @@ func TestLoadConfiguration(t *testing.T) {
 			},
 			expected: func() *Configuration {
 				cfg := DefaultConfiguration()
+				cfg.SeenBlockWorkers = runtime.NumCPU()
+				cfg.SerialBlockWorkers = runtime.NumCPU()
 				cfg.Construction = &ConstructionConfiguration{
 					OfflineURL:            DefaultURL,
 					MaxOfflineConnections: DefaultMaxOfflineConnections,
@@ -195,6 +204,8 @@ func TestLoadConfiguration(t *testing.T) {
 			},
 			expected: func() *Configuration {
 				cfg := DefaultConfiguration()
+				cfg.SeenBlockWorkers = runtime.NumCPU()
+				cfg.SerialBlockWorkers = runtime.NumCPU()
 				cfg.Construction = &ConstructionConfiguration{
 					OfflineURL:            DefaultURL,
 					MaxOfflineConnections: DefaultMaxOfflineConnections,
@@ -223,6 +234,8 @@ func TestLoadConfiguration(t *testing.T) {
 			},
 			expected: func() *Configuration {
 				cfg := DefaultConfiguration()
+				cfg.SeenBlockWorkers = runtime.NumCPU()
+				cfg.SerialBlockWorkers = runtime.NumCPU()
 				cfg.Construction = &ConstructionConfiguration{
 					OfflineURL:            DefaultURL,
 					MaxOfflineConnections: DefaultMaxOfflineConnections,
@@ -314,6 +327,8 @@ func TestLoadConfiguration(t *testing.T) {
 			},
 			expected: func() *Configuration {
 				cfg := DefaultConfiguration()
+				cfg.SeenBlockWorkers = runtime.NumCPU()
+				cfg.SerialBlockWorkers = runtime.NumCPU()
 				cfg.Data.EndConditions = &DataEndConditions{
 					ReconciliationCoverage: &ReconciliationCoverage{
 						Coverage:     goodCoverage,
@@ -371,6 +386,8 @@ func TestLoadConfiguration(t *testing.T) {
 			provided: multipleEndConditions,
 			expected: func() *Configuration {
 				def := DefaultConfiguration()
+				def.SeenBlockWorkers = runtime.NumCPU()
+				def.SerialBlockWorkers = runtime.NumCPU()
 				def.Data.EndConditions = multipleEndConditions.Data.EndConditions
 
 				return def

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -396,6 +396,16 @@ type Configuration struct {
 	// but can use 10s of GBs of RAM, even with pruning enabled.
 	MemoryLimitDisabled bool `json:"memory_limit_disabled"`
 
+	// SeenBlockWorkers is the number of goroutines spawned to store
+	// seen blocks in storage before we attempt to sequence. If not populated,
+	// this value defaults to runtime.NumCPU().
+	SeenBlockWorkers int `json:"seen_block_workers,omitempty"`
+
+	// SerialBlockWorkers is the number of goroutines spawned to help
+	// with block sequencing (i.e. updating balances, updating coins, etc).
+	// If not populated, this value defaults to runtime.NumCPU().
+	SerialBlockWorkers int `json:"serial_block_workers,omitempty"`
+
 	Construction *ConstructionConfiguration `json:"construction"`
 	Data         *DataConfiguration         `json:"data"`
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.13
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.6.4
+	github.com/coinbase/rosetta-sdk-go v0.6.5
 	github.com/fatih/color v1.10.0
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
-github.com/coinbase/rosetta-sdk-go v0.6.4 h1:+3z6otziRDdgEwy7IsyTkwgCNbbH4z5QMDnXdbdg9ZY=
-github.com/coinbase/rosetta-sdk-go v0.6.4/go.mod h1:MvQfsL2KlJ5786OdDviRIJE3agui2YcvS1CaQPDl1Yo=
+github.com/coinbase/rosetta-sdk-go v0.6.5 h1:RytFDCPXS64vEYwIOsxsoQGlZZyP9RQvzyYikxymI4w=
+github.com/coinbase/rosetta-sdk-go v0.6.5/go.mod h1:MvQfsL2KlJ5786OdDviRIJE3agui2YcvS1CaQPDl1Yo=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/results/data_results.go
+++ b/pkg/results/data_results.go
@@ -250,6 +250,7 @@ func ComputeCheckDataStats(
 	}
 
 	if balances != nil {
+		// TODO: handle nil handler/nil helper error
 		coverage, err := balances.EstimatedReconciliationCoverage(ctx)
 		if err != nil {
 			log.Printf("%s: cannot get reconcile coverage", err.Error())

--- a/pkg/results/data_results.go
+++ b/pkg/results/data_results.go
@@ -250,14 +250,17 @@ func ComputeCheckDataStats(
 	}
 
 	if balances != nil {
-		// TODO: handle nil handler/nil helper error
 		coverage, err := balances.EstimatedReconciliationCoverage(ctx)
-		if err != nil {
-			log.Printf("%s: cannot get reconcile coverage", err.Error())
+		switch {
+		case err == nil:
+			stats.ReconciliationCoverage = coverage
+		case errors.Is(err, storageErrs.ErrHelperHandlerMissing):
+			// In this case, we use the default 0 value for the reconciliation
+			// coverage in stats.
+		case err != nil:
+			log.Printf("%s: cannot get reconciliation coverage", err.Error())
 			return nil
 		}
-
-		stats.ReconciliationCoverage = coverage
 	}
 
 	return stats

--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -121,7 +121,7 @@ func InitializeConstruction(
 		false,
 	)
 
-	blockStorage := modules.NewBlockStorage(localStore)
+	blockStorage := modules.NewBlockStorage(localStore, config.SerialBlockWorkers)
 	keyStorage := modules.NewKeyStorage(localStore)
 	coinStorageHelper := processor.NewCoinStorageHelper(blockStorage)
 	coinStorage := modules.NewCoinStorage(localStore, coinStorageHelper, onlineFetcher.Asserter)
@@ -266,6 +266,7 @@ func InitializeConstruction(
 		statefulsyncer.WithCacheSize(syncer.DefaultCacheSize),
 		statefulsyncer.WithMaxConcurrency(config.MaxSyncConcurrency),
 		statefulsyncer.WithPastBlockLimit(config.MaxReorgDepth),
+		statefulsyncer.WithSeenConcurrency(int64(config.SeenBlockWorkers)),
 	)
 
 	return &ConstructionTester{

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -177,7 +177,7 @@ func InitializeData(
 	}
 
 	counterStorage := modules.NewCounterStorage(localStore)
-	blockStorage := modules.NewBlockStorage(localStore)
+	blockStorage := modules.NewBlockStorage(localStore, config.SerialBlockWorkers)
 	balanceStorage := modules.NewBalanceStorage(localStore)
 
 	logger := logger.NewLogger(
@@ -320,6 +320,7 @@ func InitializeData(
 		statefulsyncer.WithCacheSize(syncer.DefaultCacheSize),
 		statefulsyncer.WithMaxConcurrency(config.MaxSyncConcurrency),
 		statefulsyncer.WithPastBlockLimit(config.MaxReorgDepth),
+		statefulsyncer.WithSeenConcurrency(int64(config.SeenBlockWorkers)),
 	}
 	if config.Data.PruningFrequency != nil {
 		statefulSyncerOptions = append(
@@ -978,7 +979,7 @@ func (t *DataTester) recursiveOpSearch(
 	}
 
 	counterStorage := modules.NewCounterStorage(localStore)
-	blockStorage := modules.NewBlockStorage(localStore)
+	blockStorage := modules.NewBlockStorage(localStore, t.config.SerialBlockWorkers)
 	balanceStorage := modules.NewBalanceStorage(localStore)
 
 	logger := logger.NewLogger(
@@ -1055,6 +1056,7 @@ func (t *DataTester) recursiveOpSearch(
 		statefulsyncer.WithCacheSize(syncer.DefaultCacheSize),
 		statefulsyncer.WithMaxConcurrency(t.config.MaxSyncConcurrency),
 		statefulsyncer.WithPastBlockLimit(t.config.MaxReorgDepth),
+		statefulsyncer.WithSeenConcurrency(int64(t.config.SeenBlockWorkers)),
 	)
 
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-sdk-go/pull/273

Invoking BootstrapBalances in `check:data` always panics because we now invoke the BalanceStorage handler during bootstrapping (which isn't yet initialized). This PR moves BootstrapBalances to follow initialization.

**WARNING: THIS PR INCLUDES BREAKING CHANGES TO HOW DATA IS STORED ON DISK.**

### Changes
- [x] Move BootstrapBalances
- [x] Handle ErrHelperHandlerMissing 
- [x] Update `rosetta-sdk-go@v0.6.5`
- [x] Add configs for `SerialBlockWorkers` and `SeenBlockWorkers`
- [x] Update version

#### `rosetta-sdk-go` Changes
- [storage] Protect against nil Helper and/or Handler in BalanceStorage [`#273`](https://github.com/coinbase/rosetta-sdk-go/pull/273)
- [storage] Single Errgroup Pool for BlockWorkers [`#272`](https://github.com/coinbase/rosetta-sdk-go/pull/272)
- [chore] `rosetta-specifications@v1.4.9` [`#271`](https://github.com/coinbase/rosetta-sdk-go/pull/271)
- [syncer/storage] Pre-store Blocks [`#269`](https://github.com/coinbase/rosetta-sdk-go/pull/269)

### Future Work (before release)
* Implement `ForceInactiveReconciliation`
* Mark at tip if `SyncStatus.Synced` is true