### PR TITLE
End Condition Logging

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -97,11 +97,12 @@ func (l *Logger) LogDataStatus(ctx context.Context, status *results.CheckDataSta
 	}
 
 	statsMessage := fmt.Sprintf(
-		"[STATS] Blocks: %d (Orphaned: %d) Transactions: %d Operations: %d Reconciliations: %d (Inactive: %d, Exempt: %d, Skipped: %d, Coverage: %f%%)", // nolint:lll
+		"[STATS] Blocks: %d (Orphaned: %d) Transactions: %d Operations: %d Accounts: %d Reconciliations: %d (Inactive: %d, Exempt: %d, Skipped: %d, Coverage: %f%%)", // nolint:lll
 		status.Stats.Blocks,
 		status.Stats.Orphans,
 		status.Stats.Transactions,
 		status.Stats.Operations,
+		status.Stats.Accounts,
 		status.Stats.ActiveReconciliations+status.Stats.InactiveReconciliations,
 		status.Stats.InactiveReconciliations,
 		status.Stats.ExemptReconciliations,

--- a/pkg/results/data_results.go
+++ b/pkg/results/data_results.go
@@ -101,6 +101,7 @@ type CheckDataStats struct {
 	Orphans                 int64   `json:"orphans"`
 	Transactions            int64   `json:"transactions"`
 	Operations              int64   `json:"operations"`
+	Accounts                int64   `json:"accounts"`
 	ActiveReconciliations   int64   `json:"active_reconciliations"`
 	InactiveReconciliations int64   `json:"inactive_reconciliations"`
 	ExemptReconciliations   int64   `json:"exempt_reconciliations"`
@@ -126,6 +127,9 @@ func (c *CheckDataStats) Print() {
 	)
 	table.Append(
 		[]string{"Operations", "# of operations processed", strconv.FormatInt(c.Operations, 10)},
+	)
+	table.Append(
+		[]string{"Accounts", "# of accounts seen", strconv.FormatInt(c.Accounts, 10)},
 	)
 	table.Append(
 		[]string{
@@ -207,6 +211,12 @@ func ComputeCheckDataStats(
 		return nil
 	}
 
+	accounts, err := counters.Get(ctx, modules.SeenAccounts)
+	if err != nil {
+		log.Printf("%s: cannot get accounts counter", err.Error())
+		return nil
+	}
+
 	activeReconciliations, err := counters.Get(ctx, modules.ActiveReconciliationCounter)
 	if err != nil {
 		log.Printf("%s: cannot get active reconciliations counter", err.Error())
@@ -242,6 +252,7 @@ func ComputeCheckDataStats(
 		Orphans:                 orphans.Int64(),
 		Transactions:            txs.Int64(),
 		Operations:              ops.Int64(),
+		Accounts:                accounts.Int64(),
 		ActiveReconciliations:   activeReconciliations.Int64(),
 		InactiveReconciliations: inactiveReconciliations.Int64(),
 		ExemptReconciliations:   exemptReconciliations.Int64(),

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -597,10 +597,6 @@ func (t *DataTester) EndReconciliationCoverage( // nolint:gocognit
 				// by this point but we check just to be sure.
 				if t.forceInactiveReconciliation != nil {
 					*t.forceInactiveReconciliation = !disableForceReconciliation
-
-					if !disableForceReconciliation {
-						log.Println("enabling forced inactive reconciliation")
-					}
 				}
 
 				// Once at tip, we want to consider
@@ -676,6 +672,13 @@ func (t *DataTester) EndReconciliationCoverage( // nolint:gocognit
 				t.cancel()
 				return
 			}
+
+			color.Cyan(fmt.Sprintf(
+				"[END CONDITIONS] Waiting for reconciliation coverage after block %d (%f%%) to surpass required coverage (%f%%)",
+				firstTipIndex,
+				reconciliationCoverage.Coverage*utils.OneHundred,
+				coverage*utils.OneHundred,
+			))
 		}
 	}
 }

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -674,10 +674,10 @@ func (t *DataTester) EndReconciliationCoverage( // nolint:gocognit
 			}
 
 			color.Cyan(fmt.Sprintf(
-				"[END CONDITIONS] Waiting for reconciliation coverage after block %d (%f%%) to surpass required coverage (%f%%)",
+				"[END CONDITIONS] Waiting for reconciliation coverage after block %d (%f%%) to surpass requirement (%f%%)",
 				firstTipIndex,
-				reconciliationCoverage.Coverage*utils.OneHundred,
 				coverage*utils.OneHundred,
+				reconciliationCoverage.Coverage*utils.OneHundred,
 			))
 		}
 	}


### PR DESCRIPTION
This PR introduces better logging when waiting for the "reconciliation coverage from tip end condition" (which otherwise looks like the `rosetta-cli` stalls).

![image](https://user-images.githubusercontent.com/13023275/101919486-3e362f80-3b90-11eb-9560-5f2655d8f799.png)

### Changes
- [x] Print out reconciliation end condition status
- [x] Print out total seen accounts