### PR TITLE
Fix PROTO-1835

### DIFF
--- a/cmd/view_block.go
+++ b/cmd/view_block.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -66,7 +67,7 @@ func printChanges(balanceChanges []*parser.BalanceChange) error {
 	return nil
 }
 
-func runViewBlockCmd(cmd *cobra.Command, args []string) error {
+func runViewBlockCmd(_ *cobra.Command, args []string) error {
 	index, err := strconv.ParseInt(args[0], 10, 64)
 	if err != nil {
 		return fmt.Errorf("%w: unable to parse index %s", err, args[0])
@@ -121,6 +122,10 @@ func runViewBlockCmd(cmd *cobra.Command, args []string) error {
 	)
 	if fetchErr != nil {
 		return fmt.Errorf("%w: unable to fetch block", fetchErr.Err)
+	}
+	// It's valid for a block to be omitted without triggering an error
+	if block == nil {
+		return errors.New("block not found, it might be omitted")
 	}
 
 	fmt.Printf("\n")


### PR DESCRIPTION
Fixes PROTO-1835

### Motivation
A Coinbase dev reported a panic when using Rosetta CLI to view a nonexistent block

### Solution
It's possible for the SDK to return nil,nil if the block is omitted. This is expected behavior and not a bug
```
	// If a block is omitted, it will return a non-error
	// response with block equal to nil.
	if block == nil {
		return nil, nil
	} 
```

Just return early in the CLI instead of passing nil to BalanceChanges, which causes a panic because the SDK doesn't gracefully handle nil input

### Open questions
Ideally we would dig into the code some more to figure out when exactly this happens, but it's not a blocker for the ticket
