### PR TITLE
Make exempt accounts file configuration relative to main config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ bin/
 
 # Intellij setting
 .idea/
+
+# Mac files
+.DS_Store

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -334,6 +334,10 @@ func modifyFilePaths(config *Configuration, fileDir string) {
 		if len(config.Data.InterestingAccounts) > 0 {
 			config.Data.InterestingAccounts = path.Join(fileDir, config.Data.InterestingAccounts)
 		}
+
+		if len(config.Data.ExemptAccounts) > 0 {
+			config.Data.ExemptAccounts = path.Join(fileDir, config.Data.ExemptAccounts)
+		}
 	}
 
 	if config.Construction != nil {

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -351,6 +351,8 @@ type Configuration struct {
 	OnlineURL string `json:"online_url"`
 
 	// DataDirectory is a folder used to store logs and any data used to perform validation.
+	// The path can be absolute or relative to the directory containing the rosetta-cli
+	// binary.
 	DataDirectory string `json:"data_directory"`
 
 	// HTTPTimeout is the timeout for a HTTP request in seconds.

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -351,8 +351,8 @@ type Configuration struct {
 	OnlineURL string `json:"online_url"`
 
 	// DataDirectory is a folder used to store logs and any data used to perform validation.
-	// The path can be absolute or relative to the directory containing the rosetta-cli
-	// binary.
+	// The path can be absolute, or it can be relative to where rosetta-cli
+	// binary is being executed.
 	DataDirectory string `json:"data_directory"`
 
 	// HTTPTimeout is the timeout for a HTTP request in seconds.


### PR DESCRIPTION
Fixes #  https://github.com/coinbase/rosetta-cli/issues/215

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The documentation for [exempt_accounts configuration,](https://pkg.go.dev/github.com/coinbase/rosetta-cli/configuration#DataConfiguration) states that it should specify a path to a file relative to the configuration file. But, the code was actually looking for files relative to the rosetta-cli binary.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Updated behavior to match the documentation i.e. the exempt accounts file is looked up relative to the main configuration file.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
