### PR TITLE
Log transaction to terminal

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -270,15 +270,15 @@ func (l *Logger) TransactionStream(
 	defer closeFile(f)
 
 	for _, tx := range block.Transactions {
-		blockString := fmt.Sprintf(
+		transactionString := fmt.Sprintf(
 			"Transaction %s at Block %d:%s\n",
 			tx.TransactionIdentifier.Hash,
 			block.BlockIdentifier.Index,
 			block.BlockIdentifier.Hash,
 		)
 		
-		fmt.Print(blockString)
-		_, err = f.WriteString(blockString)
+		fmt.Print(transactionString)
+		_, err = f.WriteString(transactionString)
 
 		if err != nil {
 			return err

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -270,12 +270,16 @@ func (l *Logger) TransactionStream(
 	defer closeFile(f)
 
 	for _, tx := range block.Transactions {
-		_, err = f.WriteString(fmt.Sprintf(
+		blockString := fmt.Sprintf(
 			"Transaction %s at Block %d:%s\n",
 			tx.TransactionIdentifier.Hash,
 			block.BlockIdentifier.Index,
 			block.BlockIdentifier.Hash,
-		))
+		)
+		
+		fmt.Print(blockString)
+		_, err = f.WriteString(blockString)
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes # PROTO-1426

### Motivation
For block, we already log to terminal and file.
For transactions, we only log to file. We want to log to terminal as well.

### Solution
The fix is similar to what we have done in logging blocks.

### Test result:
Enable the following in config:
```
"log_blocks": true,
"log_transactions": true,
```
The terminal outputs then include the following:
```
Add Block 1216:00000000371d089aa929c618718f0844d34ba6771af480f0a30848e16b38d10a with Parent Block 1215:000000001991524d2eb48172d0aa8022609a17386c290a9a5c7b7e49462d68bb
Transaction 322bf78b2854a6c9ec32d1cda044c1e5214b291d8f6b8a153a7142ae29529b67 at Block 1216:00000000371d089aa929c618718f0844d34ba6771af480f0a30848e16b38d10a
Add Block 1217:00000000f75c09f6ae1e6e7842ebc693aef87c92cb922435a1f2a1a1b9b527de with Parent Block 1216:00000000371d089aa929c618718f0844d34ba6771af480f0a30848e16b38d10a
Transaction 6b0e6ca0c2c8f4a6abf924913ab70bc655bde08053fe6e5626bde2b4b87e5587 at Block 1217:00000000f75c09f6ae1e6e7842ebc693aef87c92cb922435a1f2a1a1b9b527de
Add Block 1218:000000008bfc8c25cb7c129c5fc433cdb572f74fda9379a2bda2c465562429c3 with Parent Block 1217:00000000f75c09f6ae1e6e7842ebc693aef87c92cb922435a1f2a1a1b9b527de
Transaction 8b541519dcdfe9aa73efcb242c0bd73c8219e47af1a132c160fddc1e3ee1b676 at Block 1218:000000008bfc8c25cb7c129c5fc433cdb572f74fda9379a2bda2c465562429c3
```

