### PR TITLE
enable validation file for other commands

### DIFF
--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -89,7 +89,7 @@ func runCheckDataCmd(_ *cobra.Command, _ []string) error {
 		fetcherOpts...,
 	)
 
-	_, _, fetchErr := fetcher.InitializeAsserter(ctx, Config.Network, "")
+	_, _, fetchErr := fetcher.InitializeAsserter(ctx, Config.Network, Config.ValidationFile)
 	if fetchErr != nil {
 		cancel()
 		return results.ExitData(

--- a/cmd/view_balance.go
+++ b/cmd/view_balance.go
@@ -72,7 +72,7 @@ func runViewBalanceCmd(cmd *cobra.Command, args []string) error {
 	)
 
 	// Initialize the fetcher's asserter
-	_, _, fetchErr := newFetcher.InitializeAsserter(Context, Config.Network, "")
+	_, _, fetchErr := newFetcher.InitializeAsserter(Context, Config.Network, Config.ValidationFile)
 	if fetchErr != nil {
 		return fmt.Errorf("%w: unable to initialize asserter", fetchErr.Err)
 	}

--- a/cmd/view_block.go
+++ b/cmd/view_block.go
@@ -94,7 +94,7 @@ func runViewBlockCmd(_ *cobra.Command, args []string) error {
 	// Behind the scenes this makes a call to get the
 	// network status and uses the response to inform
 	// the asserter what are valid responses.
-	_, _, fetchErr := newFetcher.InitializeAsserter(Context, Config.Network, "")
+	_, _, fetchErr := newFetcher.InitializeAsserter(Context, Config.Network, Config.ValidationFile)
 	if fetchErr != nil {
 		return fmt.Errorf("%w: unable to initialize asserter", fetchErr.Err)
 	}


### PR DESCRIPTION
Fixes # .

### Motivation
We want to enable validation file use for other commands. 

### Solution
Added validation config to the other command asserter intialization.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
