### PR TITLE
Use crazy-max/xgo instead of karalabke/xgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ salus:
 
 release: add-license shorten-lines format test lint salus
 
+# This command is to generate multi-platform binaries.
 compile:
 	./scripts/compile.sh $(version)
 

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -89,7 +89,7 @@ func runCheckDataCmd(_ *cobra.Command, _ []string) error {
 		fetcherOpts...,
 	)
 
-	_, _, fetchErr := fetcher.InitializeAsserter(ctx, Config.Network, "")
+	_, _, fetchErr := fetcher.InitializeAsserter(ctx, Config.Network, Config.ValidationFile)
 	if fetchErr != nil {
 		cancel()
 		return results.ExitData(

--- a/cmd/view_balance.go
+++ b/cmd/view_balance.go
@@ -72,7 +72,7 @@ func runViewBalanceCmd(cmd *cobra.Command, args []string) error {
 	)
 
 	// Initialize the fetcher's asserter
-	_, _, fetchErr := newFetcher.InitializeAsserter(Context, Config.Network, "")
+	_, _, fetchErr := newFetcher.InitializeAsserter(Context, Config.Network, Config.ValidationFile)
 	if fetchErr != nil {
 		return fmt.Errorf("%w: unable to initialize asserter", fetchErr.Err)
 	}

--- a/cmd/view_block.go
+++ b/cmd/view_block.go
@@ -94,7 +94,7 @@ func runViewBlockCmd(_ *cobra.Command, args []string) error {
 	// Behind the scenes this makes a call to get the
 	// network status and uses the response to inform
 	// the asserter what are valid responses.
-	_, _, fetchErr := newFetcher.InitializeAsserter(Context, Config.Network, "")
+	_, _, fetchErr := newFetcher.InitializeAsserter(Context, Config.Network, Config.ValidationFile)
 	if fetchErr != nil {
 		return fmt.Errorf("%w: unable to initialize asserter", fetchErr.Err)
 	}

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -16,12 +16,21 @@
 
 VERSION=$1;
 
-xgo -go go-1.15.5 --targets=darwin/*,windows/*,linux/* -out "bin/rosetta-cli-${VERSION}" .;
+go get github.com/crazy-max/xgo
+
+MAC_TARGETS="darwin/amd64,darwin/arm64"
+LINUX_TARGETS="linux/amd64,linux/arm64,linux/mips64,linux/mips64le,linux/ppc64le,linux/s390x"
+WINDOWS_TARGET="windows/amd64"
+TARGETS="${MAC_TARGETS},${LINUX_TARGETS},${WINDOWS_TARGET}"
+
+xgo -go 1.16.3 --targets=${TARGETS} -out "bin/rosetta-cli-${VERSION}" .;
 
 # Rename some files
-mv "bin/rosetta-cli-${VERSION}-darwin-10.6-amd64" "bin/rosetta-cli-${VERSION}-darwin-amd64" 
+mv "bin/rosetta-cli-${VERSION}-darwin-10.12-amd64" "bin/rosetta-cli-${VERSION}-darwin-amd64"
 mv "bin/rosetta-cli-${VERSION}-windows-4.0-amd64.exe" "bin/rosetta-cli-${VERSION}-windows-amd64"
 
 # Tar all files
 cd bin || exit;
 for i in *; do tar -czf "$i.tar.gz" "$i" && rm "$i"; done
+
+go mod tidy


### PR DESCRIPTION
Fixes # .

### Motivation
https://github.com/karalabe/xgo is not maintained anymore and also doesn't support latest go version. So we can't make new cross platform binaries with this library

### Solution
We are now using https://github.com/crazy-max/xgo for building. This is maintained and has all the latest go versions

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
