### PR TITLE
Update Version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -294,6 +294,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.6.7")
+		fmt.Println("v0.7.3")
 	},
 }


### PR DESCRIPTION
The 'version' subcommand was still showing the old v0.6.7 version.

This is being changed so that the _next_ released version will be displayed correctly.