### PR TITLE
Add m1 mac support to install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -67,6 +67,7 @@ execute() {
 get_binaries() {
   case "$PLATFORM" in
     darwin/amd64) BINARY="rosetta-cli" ;;
+    darwin/arm64) BINARY="rosetta-cli" ;;
     linux/amd64) BINARY="rosetta-cli" ;;
     linux/arm64) BINARY="rosetta-cli" ;;
     linux/mips64) BINARY="rosetta-cli" ;;


### PR DESCRIPTION
Fixes the install script.

### Motivation
Allow M1 Macs to pull darwin/arm64 build of rosetta-cli

### Solution
Add a line in the install script to reference the build
