### PR TITLE
config consistency

### DIFF
--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -29,13 +29,13 @@ import (
 )
 
 var (
-	startIndex        = int64(89)
-	badStartIndex     = int64(-10)
-	goodCoverage      = float64(0.33)
-	badCoverage       = float64(-2)
-	endTip            = false
-	historicalEnabled = true
-	fakeWorkflows     = []*job.Workflow{
+	startIndex         = int64(89)
+	badStartIndex      = int64(-10)
+	goodCoverage       = float64(0.33)
+	badCoverage        = float64(-2)
+	endTip             = false
+	historicalDisabled = false
+	fakeWorkflows      = []*job.Workflow{
 		{
 			Name:        string(job.CreateAccount),
 			Concurrency: job.ReservedWorkflowConcurrency,
@@ -62,16 +62,16 @@ var (
 			Blockchain: "sweet",
 			Network:    "sweeter",
 		},
-		OnlineURL:              "http://hasudhasjkdk",
-		MaxOnlineConnections:   10,
-		HTTPTimeout:            21,
-		MaxRetries:             1000,
-		MaxSyncConcurrency:     12,
-		TipDelay:               1231,
-		MaxReorgDepth:          12,
-		SeenBlockWorkers:       300,
-		SerialBlockWorkers:     200,
-		ErrorStackTraceEnabled: true,
+		OnlineURL:               "http://hasudhasjkdk",
+		MaxOnlineConnections:    10,
+		HTTPTimeout:             21,
+		MaxRetries:              1000,
+		MaxSyncConcurrency:      12,
+		TipDelay:                1231,
+		MaxReorgDepth:           12,
+		SeenBlockWorkers:        300,
+		SerialBlockWorkers:      200,
+		ErrorStackTraceDisabled: false,
 		Construction: &ConstructionConfiguration{
 			OfflineURL:            "https://ashdjaksdkjshdk",
 			MaxOfflineConnections: 21,
@@ -92,7 +92,7 @@ var (
 			InactiveReconciliationConcurrency: 2938,
 			InactiveReconciliationFrequency:   3,
 			ReconciliationDisabled:            false,
-			HistoricalBalanceEnabled:          &historicalEnabled,
+			HistoricalBalanceDisabled:         &historicalDisabled,
 			StartIndex:                        &startIndex,
 			StatusPort:                        123,
 			EndConditions: &DataEndConditions{

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -258,11 +258,11 @@ type DataConfiguration struct {
 	// beginning syncing, it will be ignored.
 	BootstrapBalances string `json:"bootstrap_balances"`
 
-	// HistoricalBalanceEnabled is a boolean that dictates how balance lookup is performed.
-	// When set to true, balances are looked up at the block where a balance
+	// HistoricalBalanceDisabled is a boolean that dictates how balance lookup is performed.
+	// When set to false, balances are looked up at the block where a balance
 	// change occurred instead of at the current block. Blockchains that do not support
-	// historical balance lookup should set this to false.
-	HistoricalBalanceEnabled *bool `json:"historical_balance_enabled,omitempty"`
+	// historical balance lookup should set this to true.
+	HistoricalBalanceDisabled *bool `json:"historical_balance_disabled,omitempty"`
 
 	// InterestingAccounts is a path to a file listing all accounts to check on each block. Look
 	// at the examples directory for an example of how to structure this file.
@@ -421,9 +421,9 @@ type Configuration struct {
 	// specific validation will be done
 	ValidationFile string `json:"validation_file,omitempty"`
 
-	// ErrorStackTraceEnabled if true then it will print error stack trace
+	// ErrorStackTraceDisabled if true then it will print error stack trace
 	// if the data or construction check fails
-	ErrorStackTraceEnabled bool `json:"error_stack_trace_enabled"`
+	ErrorStackTraceDisabled bool `json:"error_stack_trace_disabled"`
 
 	Construction *ConstructionConfiguration `json:"construction"`
 	Data         *DataConfiguration         `json:"data"`

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -421,7 +421,7 @@ type Configuration struct {
 	// specific validation will be done
 	ValidationFile string `json:"validation_file,omitempty"`
 
-	// ErrorStackTraceDisabled if true then it will print error stack trace
+	// ErrorStackTraceDisabled if false then it will print error stack trace
 	// if the data or construction check fails
 	ErrorStackTraceDisabled bool `json:"error_stack_trace_disabled"`
 

--- a/examples/configuration/default.json
+++ b/examples/configuration/default.json
@@ -15,7 +15,7 @@
  "log_configuration": false,
  "compression_disabled": false,
  "memory_limit_disabled": false,
- "error_stack_trace_enabled": false,
+ "error_stack_trace_disabled": false,
  "construction": null,
  "data": {
   "active_reconciliation_concurrency": 16,

--- a/examples/configuration/simple.json
+++ b/examples/configuration/simple.json
@@ -8,7 +8,7 @@
  "http_timeout": 10,
  "tip_delay": 300,
  "data": {
-  "historical_balance_enabled": false,
+  "historical_balance_disabled": true,
   "reconciliation_disabled": true,
   "inactive_discrepancy_search_disabled": true,
   "balance_tracking_disabled": true,

--- a/pkg/results/construction_results.go
+++ b/pkg/results/construction_results.go
@@ -301,7 +301,7 @@ func ExitConstruction(
 	jobStorage *modules.JobStorage,
 	err error,
 ) error {
-	if config.ErrorStackTraceEnabled {
+	if !config.ErrorStackTraceDisabled {
 		err = pkgError.WithStack(err)
 	}
 

--- a/pkg/results/data_results.go
+++ b/pkg/results/data_results.go
@@ -709,7 +709,7 @@ func ExitData(
 	endCondition configuration.CheckDataEndCondition,
 	endConditionDetail string,
 ) error {
-	if config.ErrorStackTraceEnabled {
+	if !config.ErrorStackTraceDisabled {
 		err = pkgError.WithStack(err)
 	}
 

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -230,8 +230,8 @@ func InitializeData(
 
 	// Determine if we should perform historical balance lookups
 	var historicalBalanceEnabled bool
-	if config.Data.HistoricalBalanceEnabled != nil {
-		historicalBalanceEnabled = *config.Data.HistoricalBalanceEnabled
+	if config.Data.HistoricalBalanceDisabled != nil {
+		historicalBalanceEnabled = !*config.Data.HistoricalBalanceDisabled
 	} else { // we must look it up
 		historicalBalanceEnabled = networkOptions.Allow.HistoricalBalanceLookup
 	}


### PR DESCRIPTION
Fixes #194  .

### Motivation
The `bool` config in rosetta-cli conf has variables with both `*enabled` and `*disabled` suffixes which is inconsistent and creates confusion.

### Solution
Making all the config `*disabled`

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
