### PR TITLE
Fix panic in check:configuration command

### DIFF
--- a/pkg/results/construction_results.go
+++ b/pkg/results/construction_results.go
@@ -313,7 +313,9 @@ func ExitConstruction(
 	)
 	if results != nil {
 		results.Print()
-		results.Output(config.Construction.ResultsOutputFile)
+		if config.Construction != nil {
+			results.Output(config.Construction.ResultsOutputFile)
+		}
 	}
 
 	return err


### PR DESCRIPTION
### Motivation
This PR addresses #269

### Solution
Just adds a nil check around https://github.com/coinbase/rosetta-cli/blob/master/pkg/results/construction_results.go#L316

### Open questions
I generally don't like for users to see stack traces at all (especially in this case where cobra provides the usage message and a meaningful error).  Have you considered making `ErrorStackTraceDisabled` set to `true` by default so that the user only sees the usage message, descriptive error and a nonzero return code?
