### PR TITLE
Include operations from related transactions to match intent

### DIFF
--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -261,6 +261,7 @@ func InitializeConstruction(
 
 	broadcastHandler := processor.NewBroadcastStorageHandler(
 		config,
+		blockStorage,
 		counterStorage,
 		coordinator,
 		parser,


### PR DESCRIPTION
We should pass the check if we can find the intent operation in related transactions.