### PR TITLE
Update rosetta-sdk-go version to 0.7.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/rosetta-cli
 go 1.16
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.7.6
+	github.com/coinbase/rosetta-sdk-go v0.7.7
 	github.com/fatih/color v1.13.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/coinbase/kryptology v1.8.0 h1:Aoq4gdTsJhSU3lNWsD5BWmFSz2pE0GlmrljaOxepdYY=
 github.com/coinbase/kryptology v1.8.0/go.mod h1:RYXOAPdzOGUe3qlSFkMGn58i3xUA8hmxYHksuq+8ciI=
-github.com/coinbase/rosetta-sdk-go v0.7.6 h1:y3/Lxu9ojIsUKnhNc5UaZF/i0byfuNDWXLYMSKG+IBs=
-github.com/coinbase/rosetta-sdk-go v0.7.6/go.mod h1:lt2lJX/HQ2stryuKkukCWMcX3T5fBU62UrdhuwsnVYg=
+github.com/coinbase/rosetta-sdk-go v0.7.7 h1:1b4YhFs4hE7sjRlsJ16VBow1cq0NfmKY2v9tT1PKx7I=
+github.com/coinbase/rosetta-sdk-go v0.7.7/go.mod h1:lt2lJX/HQ2stryuKkukCWMcX3T5fBU62UrdhuwsnVYg=
 github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572/go.mod h1:Bpd0/3mZuaj6Sj+PqrmIquiOKy397AKGThQPaGzNXAQ=
 github.com/consensys/bavard v0.1.8-0.20210915155054-088da2f7f54a/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f/go.mod h1:815PAHg3wvysy0SyIqanF8gZ0Y1wjk/hrDHD/iT88+Q=


### PR DESCRIPTION
Fixes # .

### Motivation
Update rosetta-sdk-go version to 0.7.7.

### Solution
0.7.7 is the latest version we should use for bug fix of UTXO chains.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
