### PR TITLE
rosetta-cli version should return latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,7 @@ You can also find community implementations for a variety of blockchains in the 
 ## License
 This project is available open source under the terms of the [Apache 2.0 License](https://opensource.org/licenses/Apache-2.0).
 
+## Release
+When we release a new rosetta-cli version, please update the [version number](https://github.com/coinbase/rosetta-cli/blob/master/cmd/root.go#L297) so that `rosetta-cli version` command can print the correct value.
+
 © 2022 Coinbase

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -294,6 +294,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.7.3")
+		fmt.Println("v0.7.6")
 	},
 }


### PR DESCRIPTION
Fixes # .

### Motivation
ROSE-251: rosetta-cli version should return latest release

### Solution
See PR for details

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
