### PR TITLE
implement check:spec for construction API

### DIFF
--- a/cmd/check_spec.go
+++ b/cmd/check_spec.go
@@ -17,6 +17,13 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/coinbase/rosetta-cli/pkg/processor"
+	"github.com/coinbase/rosetta-sdk-go/constructor/job"
+	"github.com/coinbase/rosetta-sdk-go/constructor/worker"
+	"github.com/coinbase/rosetta-sdk-go/keys"
+	"github.com/coinbase/rosetta-sdk-go/utils"
+	"github.com/tidwall/sjson"
+	"log"
 	"time"
 
 	"github.com/coinbase/rosetta-cli/pkg/results"
@@ -37,8 +44,9 @@ var (
 )
 
 type checkSpec struct {
-	onlineFetcher  *fetcher.Fetcher
-	offlineFetcher *fetcher.Fetcher
+	onlineFetcher     *fetcher.Fetcher
+	offlineFetcher    *fetcher.Fetcher
+	coordinatorHelper *processor.CoordinatorHelper
 }
 
 func newCheckSpec(ctx context.Context) (*checkSpec, error) {
@@ -86,9 +94,24 @@ func newCheckSpec(ctx context.Context) (*checkSpec, error) {
 		)
 	}
 
+	_, _, fetchErr = offlineFetcher.InitializeAsserter(ctx, Config.Network, Config.ValidationFile)
+	if fetchErr != nil {
+		return nil, results.ExitData(
+			Config,
+			nil,
+			nil,
+			fmt.Errorf("%w: unable to initialize asserter for offline node fetcher", fetchErr.Err),
+			"",
+			"",
+		)
+	}
+
+	coordinatorHelper := processor.NewCoordinatorHelper(offlineFetcher, onlineFetcher, nil, nil, nil, nil, nil, nil, nil, nil, Config.Construction.Quiet)
+
 	return &checkSpec{
-		onlineFetcher:  onlineFetcher,
-		offlineFetcher: offlineFetcher,
+		onlineFetcher:     onlineFetcher,
+		offlineFetcher:    offlineFetcher,
+		coordinatorHelper: coordinatorHelper,
 	}, nil
 }
 
@@ -107,7 +130,7 @@ func (cs *checkSpec) networkOptions(ctx context.Context) checkSpecOutput {
 	res, err := cs.offlineFetcher.NetworkOptionsRetry(ctx, Config.Network, nil)
 	if err != nil {
 		printError("%v: unable to fetch network options\n", err.Err)
-		markAllValidationsFailed(output)
+		markAllValidationsStatus(output, checkSpecFailure)
 		return output
 	}
 
@@ -176,7 +199,7 @@ func (cs *checkSpec) networkStatus(ctx context.Context) checkSpecOutput {
 	res, err := cs.onlineFetcher.NetworkStatusRetry(ctx, Config.Network, nil)
 	if err != nil {
 		printError("%v: unable to fetch network status\n", err.Err)
-		markAllValidationsFailed(output)
+		markAllValidationsStatus(output, checkSpecFailure)
 		return output
 	}
 
@@ -216,7 +239,7 @@ func (cs *checkSpec) networkList(ctx context.Context) checkSpecOutput {
 	networks, err := cs.offlineFetcher.NetworkList(ctx, nil)
 	if err != nil {
 		printError("%v: unable to fetch network list", err.Err)
-		markAllValidationsFailed(output)
+		markAllValidationsStatus(output, checkSpecFailure)
 		return output
 	}
 
@@ -250,12 +273,12 @@ func (cs *checkSpec) accountBalance(ctx context.Context) checkSpecOutput {
 
 	acct, partBlockID, currencies, err := cs.getAccount(ctx)
 	if err != nil {
-		markAllValidationsFailed(output)
+		markAllValidationsStatus(output, checkSpecFailure)
 		printError("%v: unable to get an account\n", err)
 		return output
 	}
 	if acct == nil {
-		markAllValidationsFailed(output)
+		markAllValidationsStatus(output, checkSpecFailure)
 		printError("%v\n", errAccountNullPointer)
 		return output
 	}
@@ -268,7 +291,7 @@ func (cs *checkSpec) accountBalance(ctx context.Context) checkSpecOutput {
 		partBlockID,
 		currencies)
 	if err != nil {
-		markAllValidationsFailed(output)
+		markAllValidationsStatus(output, checkSpecFailure)
 		printError("%v: unable to fetch balance for account: %v\n", fetchErr.Err, *acct)
 		return output
 	}
@@ -303,12 +326,12 @@ func (cs *checkSpec) accountCoins(ctx context.Context) checkSpecOutput {
 		acct, _, currencies, err := cs.getAccount(ctx)
 		if err != nil {
 			printError("%v: unable to get an account\n", err)
-			markAllValidationsFailed(output)
+			markAllValidationsStatus(output, checkSpecFailure)
 			return output
 		}
 		if err != nil {
 			printError("%v\n", errAccountNullPointer)
-			markAllValidationsFailed(output)
+			markAllValidationsStatus(output, checkSpecFailure)
 			return output
 		}
 
@@ -320,7 +343,7 @@ func (cs *checkSpec) accountCoins(ctx context.Context) checkSpecOutput {
 			currencies)
 		if fetchErr != nil {
 			printError("%v: unable to get coins for account: %v\n", fetchErr.Err, *acct)
-			markAllValidationsFailed(output)
+			markAllValidationsStatus(output, checkSpecFailure)
 			return output
 		}
 
@@ -356,7 +379,7 @@ func (cs *checkSpec) block(ctx context.Context) checkSpecOutput {
 	res, fetchErr := cs.onlineFetcher.NetworkStatusRetry(ctx, Config.Network, nil)
 	if fetchErr != nil {
 		printError("%v: unable to get network status\n", fetchErr.Err)
-		markAllValidationsFailed(output)
+		markAllValidationsStatus(output, checkSpecFailure)
 		return output
 	}
 
@@ -372,7 +395,7 @@ func (cs *checkSpec) block(ctx context.Context) checkSpecOutput {
 		b, fetchErr := cs.onlineFetcher.BlockRetry(ctx, Config.Network, &blockID)
 		if fetchErr != nil {
 			printError("%v: unable to fetch block %v\n", fetchErr.Err, blockID)
-			markAllValidationsFailed(output)
+			markAllValidationsStatus(output, checkSpecFailure)
 			return output
 		}
 
@@ -505,6 +528,433 @@ func (cs *checkSpec) getAccount(ctx context.Context) (
 	return acct, blockID, currencies, nil
 }
 
+func (cs *checkSpec) ConstructionPreprocess(ctx context.Context, broadcast *job.Broadcast) (map[string]interface{}, error) {
+	printInfo("validating /construction/preprocess ...\n")
+	output := checkSpecConstructionOutput[constructionPreprocess]
+	defer printInfo("/construction/preprocess validated\n")
+
+	metadata, _, err := cs.coordinatorHelper.Preprocess(
+		ctx,
+		broadcast.Network,
+		broadcast.Intent,
+		broadcast.Metadata,
+	)
+	if err != nil {
+		markAllValidationsStatus(output, checkSpecFailure)
+		return nil, fmt.Errorf("%w: unable to send preprocess request \n", err)
+	}
+	markAllValidationsStatus(output, checkSpecSuccess)
+	return metadata, nil
+}
+
+func (cs *checkSpec) ConstructionMetadata(
+	ctx context.Context,
+	broadcast *job.Broadcast,
+	metadata map[string]interface{},
+	publicKeys []*types.PublicKey,
+) (map[string]interface{}, error) {
+	printInfo("validating /construction/metadata ...\n")
+	output := checkSpecConstructionOutput[constructionMetadata]
+	defer printInfo("/construction/metadata validated\n")
+
+	// TODO: fill pk
+	metadata, _, err := cs.coordinatorHelper.Metadata(ctx, broadcast.Network, metadata, nil)
+	if err != nil {
+		markAllValidationsStatus(output, checkSpecFailure)
+		return nil, fmt.Errorf("%w: unable to send metadata request \n", err)
+	}
+	if metadata == nil {
+		markAllValidationsStatus(output, checkSpecFailure)
+		return nil, fmt.Errorf("metadata is required \n")
+	}
+	markAllValidationsStatus(output, checkSpecSuccess)
+	return metadata, nil
+}
+
+func (cs *checkSpec) ConstructionPayloads(ctx context.Context, broadcast *job.Broadcast, metadata map[string]interface{}) (string, []*types.SigningPayload, error) {
+	printInfo("validating /construction/payloads ...\n")
+	output := checkSpecConstructionOutput[constructionPayloads]
+	defer printInfo("/construction/payloads validated\n")
+
+	unsignedTransaction, payloads, err := cs.coordinatorHelper.Payloads(
+		ctx,
+		broadcast.Network,
+		broadcast.Intent,
+		metadata,
+		nil,
+	)
+	if err != nil {
+		markAllValidationsStatus(output, checkSpecFailure)
+		return "", nil, fmt.Errorf("%w: unable to send payloads request \n", err)
+	}
+	var requirementErr error
+	if len(unsignedTransaction) == 0 {
+		requirementErr = fmt.Errorf("unsigned transaction is required \n")
+		setValidationStatus(output, unsignedTx, checkSpecFailure)
+	}
+	if len(payloads) == 0 {
+		requirementErr = fmt.Errorf("payloads is required")
+		setValidationStatus(output, signingPayloads, checkSpecFailure)
+	}
+	if requirementErr != nil {
+		return "", nil, requirementErr
+	}
+	markAllValidationsStatus(output, checkSpecSuccess)
+	return unsignedTransaction, payloads, nil
+}
+
+func (cs *checkSpec) ConstructionParse(ctx context.Context, broadcast *job.Broadcast, unsignedTransaction string) error {
+	printInfo("validating /construction/parse ...\n")
+	output := checkSpecConstructionOutput[constructionParse]
+	defer printInfo("/construction/parse validated\n")
+
+	_, _, _, err := cs.coordinatorHelper.Parse(ctx, broadcast.Network, false, unsignedTransaction)
+	if err != nil {
+		markAllValidationsStatus(output, checkSpecFailure)
+		return fmt.Errorf("%w: unable to send parse request \n", err)
+	}
+	markAllValidationsStatus(output, checkSpecSuccess)
+	return nil
+}
+
+func (cs *checkSpec) ConstructionCombine(ctx context.Context, broadcast *job.Broadcast, unsignedTransaction string, signatures []*types.Signature) (string, error) {
+	printInfo("validating /construction/combine ...\n")
+	output := checkSpecConstructionOutput[constructionCombine]
+	defer printInfo("/construction/combine validated\n")
+
+	networkTransaction, err := cs.coordinatorHelper.Combine(ctx, broadcast.Network, unsignedTransaction, signatures)
+	if err != nil {
+		markAllValidationsStatus(output, checkSpecFailure)
+		return "", fmt.Errorf("%w: unable to send combine request \n", err)
+	}
+	if len(networkTransaction) == 0 {
+		markAllValidationsStatus(output, checkSpecFailure)
+		return "", fmt.Errorf("%w: signed_transaction is required \n", err)
+	}
+	markAllValidationsStatus(output, checkSpecSuccess)
+	return networkTransaction, err
+}
+
+func (cs *checkSpec) ConstructionHash(ctx context.Context, broadcast *job.Broadcast, networkTransaction string) (*types.TransactionIdentifier, error) {
+	printInfo("validating /construction/hash ...\n")
+	output := checkSpecConstructionOutput[constructionHash]
+	defer printInfo("/construction/hash validated\n")
+
+	res, err := cs.coordinatorHelper.Hash(ctx, broadcast.Network, networkTransaction)
+	if err != nil {
+		markAllValidationsStatus(output, checkSpecFailure)
+		return nil, fmt.Errorf("%w: unable to send hash request", err)
+	}
+	if res == nil {
+		markAllValidationsStatus(output, checkSpecFailure)
+		return nil, fmt.Errorf("%w: transaction_identifier is required", err)
+	}
+	markAllValidationsStatus(output, checkSpecSuccess)
+	return res, err
+}
+
+func (cs *checkSpec) checkConstruction(ctx context.Context) map[checkSpecAPI]checkSpecOutput {
+	if len(Config.Construction.PrefundedAccounts) == 0 {
+		printError("no prefunded account provided")
+		return checkSpecConstructionOutput
+	}
+
+	// Get keypair from prefunded account
+	curveType := Config.Construction.PrefundedAccounts[0].CurveType
+	prefundedAccount := Config.Construction.PrefundedAccounts[0]
+	senderKeypair, err := keys.ImportPrivateKey(prefundedAccount.PrivateKeyHex, curveType)
+	if err != nil {
+		printError("%v: failed to generate key pair from prefunded account: %v", err, prefundedAccount.AccountIdentifier)
+		return checkSpecConstructionOutput
+	}
+
+	// Generate broadcast from transfer workflow in DSL file
+	workflows := Config.Construction.Workflows
+	var broadcast *job.Broadcast
+	for _, workflow := range workflows {
+		if workflow.Name == "transfer" {
+			broadcast, err = cs.parseTransferFromDSL(ctx, workflow)
+			if err != nil {
+				printError("%w: failed to parse transfer workflow from DSL file", err)
+				return checkSpecConstructionOutput
+			}
+		}
+	}
+
+	// Generate transaction
+	metadata, err := cs.ConstructionPreprocess(ctx, broadcast)
+	if err != nil {
+		printError(err.Error())
+		return checkSpecConstructionOutput
+	}
+
+	metadata, err = cs.ConstructionMetadata(ctx, broadcast, metadata, nil)
+	if err != nil {
+		printError(err.Error())
+		return checkSpecConstructionOutput
+	}
+
+	unsignedTransaction, payloads, err := cs.ConstructionPayloads(ctx, broadcast, metadata)
+	if err != nil {
+		printError(err.Error())
+		return checkSpecConstructionOutput
+	}
+
+	err = cs.ConstructionParse(ctx, broadcast, unsignedTransaction)
+	if err != nil {
+		printError(err.Error())
+		return checkSpecConstructionOutput
+	}
+
+	signatures, err := sign(payloads, senderKeypair)
+	if err != nil {
+		printError(err.Error())
+		return checkSpecConstructionOutput
+	}
+
+	networkTransaction, err := cs.ConstructionCombine(ctx, broadcast, unsignedTransaction, signatures)
+	if err != nil {
+		printError(err.Error())
+		return checkSpecConstructionOutput
+	}
+
+	signedTxID, err := cs.ConstructionHash(ctx, broadcast, networkTransaction)
+	if err != nil {
+		printError(err.Error())
+		return checkSpecConstructionOutput
+	}
+	fmt.Printf("+%v \n", signedTxID)
+
+	// TODO: constructionSubmit
+	return checkSpecConstructionOutput
+}
+
+func (cs *checkSpec) parseTransferFromDSL(ctx context.Context, workflow *job.Workflow) (*job.Broadcast, error) {
+	job := job.New(workflow)
+	// Increase by 1 so that broadcast instance can be generated successfully
+	job.Index = 1
+
+	var state string
+	// Parsing actions, similar to:
+	// https://github.com/coinbase/rosetta-sdk-go/blob/master/constructor/worker/worker.go#L92-L140
+	for _, scenario := range workflow.Scenarios {
+		state, err := cs.ProcessNextScenario(ctx, scenario, state)
+		if err != nil {
+			return nil, err
+		}
+		job.State = state
+	}
+
+	broadcast, err := job.CreateBroadcast()
+	if err != nil {
+		return nil, err
+	}
+	return broadcast, nil
+}
+
+func (cs *checkSpec) ProcessNextScenario(ctx context.Context, scenario *job.Scenario, state string) (string, error) {
+	for _, action := range scenario.Actions {
+		processedInput, err := worker.PopulateInput(state, action.Input)
+		if err != nil {
+			return "", fmt.Errorf("%w: unable to populate variables", err)
+		}
+
+		output, err := cs.invokeWorker(ctx, action.Type, processedInput)
+		if err != nil {
+			return "", fmt.Errorf("%w: unable to process action", err)
+		}
+
+		if len(output) == 0 {
+			continue
+		}
+
+		state, err = sjson.SetRaw(state, action.OutputPath, output)
+		if err != nil {
+			return "", fmt.Errorf("%w: unable to update state", err)
+		}
+	}
+	return state, nil
+}
+
+// invokeWorker function is similar to https://github.com/coinbase/rosetta-sdk-go/blob/master/constructor/worker/worker.go#L49-L90
+// This new function avoids using any db operation, and it's specifically for Transfer workflow
+func (cs *checkSpec) invokeWorker(
+	ctx context.Context,
+	action job.ActionType,
+	input string,
+) (string, error) {
+	switch action {
+	case job.SetVariable:
+		return input, nil
+	case job.PrintMessage:
+		worker.PrintMessageWorker(input)
+		return "", nil
+	case job.RandomString:
+		return worker.RandomStringWorker(input)
+	case job.Math:
+		return worker.MathWorker(input)
+	case job.FindBalance:
+		var balanceInput job.FindBalanceInput
+		err := job.UnmarshalInput([]byte(input), &balanceInput)
+		if err != nil {
+			return "", fmt.Errorf("%w: %s", worker.ErrInvalidInput, err.Error())
+		}
+		return cs.findBalanceWorker(ctx, &balanceInput)
+	case job.RandomNumber:
+		return worker.RandomNumberWorker(input)
+	case job.Assert:
+		return "", worker.AssertWorker(input)
+	case job.FindCurrencyAmount:
+		return worker.FindCurrencyAmountWorker(input)
+	case job.LoadEnv:
+		return worker.LoadEnvWorker(input)
+	case job.HTTPRequest:
+		return worker.HTTPRequestWorker(input)
+	default:
+		return "", fmt.Errorf("%w: %s", worker.ErrInvalidActionType, action)
+	}
+}
+
+func (cs *checkSpec) findBalanceWorker(
+	ctx context.Context,
+	input *job.FindBalanceInput,
+) (string, error) {
+	res, err := cs.onlineFetcher.NetworkStatusRetry(ctx, Config.Network, nil)
+	if err != nil {
+		return "", fmt.Errorf("%v: unable to get network status", err.Err)
+	}
+	currentBlockID := res.CurrentBlockIdentifier
+	currentPartialBlockID := types.PartialBlockIdentifier{Hash: &currentBlockID.Hash}
+
+	if input.MinimumBalance.Value == "0" {
+		return cs.generateRecipientAccount(ctx)
+	}
+	if Config.CoinSupported {
+		res, err := cs.checkAccountCoins(ctx, input)
+		if err != nil {
+			return "", err
+		}
+		return res, nil
+	} else {
+		res, err := cs.checkAccountBalance(ctx, input, currentPartialBlockID)
+		if err != nil {
+			return "", err
+		}
+		return res, nil
+	}
+}
+
+func (cs *checkSpec) generateRecipientAccount(ctx context.Context) (string, error) {
+	// Generate keypair for recipient
+	curveType := Config.Construction.PrefundedAccounts[0].CurveType
+	recipientKeypair, err := keys.GenerateKeypair(curveType)
+	if err != nil {
+		printError("%v: failed to generate key pair from curve type: %v", err, curveType)
+		return "", err
+	}
+
+	// Generate address from recipient pk
+	recipientAccount, _, err := cs.coordinatorHelper.Derive(ctx,
+		Config.Network,
+		recipientKeypair.PublicKey,
+		nil,
+	)
+	if err != nil {
+		return "", fmt.Errorf("%w: unable to generate recipient account", err)
+	}
+	return types.PrintStruct(&job.FindBalanceOutput{
+		AccountIdentifier: recipientAccount,
+	}), nil
+}
+
+func (cs *checkSpec) checkAccountBalance(
+	ctx context.Context,
+	input *job.FindBalanceInput,
+	currentPartialBlockID types.PartialBlockIdentifier,
+) (string, error) {
+	for _, account := range Config.Construction.PrefundedAccounts {
+		currencies := []*types.Currency{account.Currency}
+		_, amounts, _, err := cs.onlineFetcher.AccountBalanceRetry(ctx, Config.Network, account.AccountIdentifier, &currentPartialBlockID, currencies)
+		if err != nil {
+			return "", err.Err
+		}
+
+		for _, amount := range amounts {
+			// look for amounts > min
+			diff, err := types.SubtractValues(amount.Value, input.MinimumBalance.Value)
+			if err != nil {
+				return "", fmt.Errorf("%w: %s", worker.ErrActionFailed, err.Error())
+			}
+
+			bigIntDiff, err := types.BigInt(diff)
+			if err != nil {
+				return "", fmt.Errorf("%w: %s", worker.ErrActionFailed, err.Error())
+			}
+
+			if bigIntDiff.Sign() < 0 {
+				log.Printf(
+					"checkAccountBalance: Account (%s) has balance (%s), less than the minimum balance (%s)",
+					account.AccountIdentifier.Address,
+					amount.Value,
+					input.MinimumBalance.Value,
+				)
+				return "", nil
+			}
+
+			return types.PrintStruct(&job.FindBalanceOutput{
+				AccountIdentifier: account.AccountIdentifier,
+				Balance:           amount,
+			}), nil
+		}
+	}
+	return "", fmt.Errorf("no prefunded accounts have enough fund")
+}
+
+func (cs *checkSpec) checkAccountCoins(
+	ctx context.Context,
+	input *job.FindBalanceInput,
+) (string, error) {
+	for _, account := range Config.Construction.PrefundedAccounts {
+		currencies := []*types.Currency{account.Currency}
+		_, coins, _, err := cs.onlineFetcher.AccountCoinsRetry(ctx, Config.Network, account.AccountIdentifier, false, currencies)
+		if err != nil {
+			return "", err.Err
+		}
+		var disallowedCoins []string
+		for _, coinIdentifier := range input.NotCoins {
+			disallowedCoins = append(disallowedCoins, types.Hash(coinIdentifier))
+		}
+		for _, coin := range coins {
+			if utils.ContainsString(disallowedCoins, types.Hash(coin.CoinIdentifier)) {
+				continue
+			}
+			if coin.Amount.Value < input.MinimumBalance.Value || coin.Amount.Currency != input.MinimumBalance.Currency {
+				continue
+			}
+			diff, err := types.SubtractValues(coin.Amount.Value, input.MinimumBalance.Value)
+			if err != nil {
+				return "", fmt.Errorf("%w: %s", worker.ErrActionFailed, err.Error())
+			}
+
+			bigIntDiff, err := types.BigInt(diff)
+			if err != nil {
+				return "", fmt.Errorf("%w: %s", worker.ErrActionFailed, err.Error())
+			}
+
+			if bigIntDiff.Sign() < 0 {
+				continue
+			}
+
+			return types.PrintStruct(&job.FindBalanceOutput{
+				AccountIdentifier: account.AccountIdentifier,
+				Balance:           coin.Amount,
+				Coin:              coin.CoinIdentifier,
+			}), nil
+		}
+	}
+	return "", fmt.Errorf("no prefunded accounts have enough fund")
+}
+
 func runCheckSpecCmd(_ *cobra.Command, _ []string) error {
 	ctx := context.Background()
 	cs, err := newCheckSpec(ctx)
@@ -522,6 +972,11 @@ func runCheckSpecCmd(_ *cobra.Command, _ []string) error {
 	output = append(output, cs.block(ctx))
 	output = append(output, cs.errorObject(ctx))
 	output = append(output, twoModes())
+
+	cs.checkConstruction(ctx)
+	for _, o := range checkSpecConstructionOutput {
+		printCheckSpecOutputBody(o)
+	}
 
 	printInfo("check:spec is complete\n")
 	printCheckSpecOutputHeader()

--- a/cmd/check_spec_utils.go
+++ b/cmd/check_spec_utils.go
@@ -57,6 +57,12 @@ var (
 	errBlockTip                    = errors.New("unspecified block_identifier doesn't give the tip block")
 	errRosettaConfigNoConstruction = errors.New("no construction element in Rosetta config")
 
+	errMetadataNullPointer      = errors.New("null pointer to metadata object")
+	errUnsignedTransactionEmpty = errors.New("unsigned transaction can't be empty")
+	errPayloadEmpty             = errors.New("payloads can't be empty")
+	errSignedTransactionEmpty   = errors.New("signed transaction can't be empty")
+	errTransactionNullPointer   = errors.New("null pointer to transaction identifier")
+
 	checkSpecConstructionOutput = map[checkSpecAPI]checkSpecOutput{
 		constructionPreprocess: {
 			api: constructionPreprocess,
@@ -441,4 +447,16 @@ func sign(payloads []*types.SigningPayload, keyPair *keys.KeyPair) ([]*types.Sig
 	}
 
 	return signatures, nil
+}
+
+func sortConstructionOutput() []checkSpecOutput {
+	var output []checkSpecOutput
+	output = append(output, checkSpecConstructionOutput[constructionPreprocess])
+	output = append(output, checkSpecConstructionOutput[constructionMetadata])
+	output = append(output, checkSpecConstructionOutput[constructionParse])
+	output = append(output, checkSpecConstructionOutput[constructionPayloads])
+	output = append(output, checkSpecConstructionOutput[constructionCombine])
+	output = append(output, checkSpecConstructionOutput[constructionHash])
+	output = append(output, checkSpecConstructionOutput[constructionSubmit])
+	return output
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.1
+	github.com/tidwall/sjson v1.2.4 // indirect
 	go.uber.org/zap v1.21.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c


### PR DESCRIPTION
Fixes # .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
check:spec for construction API
### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
### How is it tested
Tested in both UTXO and account based chain.
#### UTXO: avalanche
Ran `check:spec --configuration-file conf.json`, conf.json and dsl file are located in [here](https://github.com/ava-labs/avalanche-rosetta/blob/master/rosetta-cli-conf/testnet/config.json) and [here](https://github.com/ava-labs/avalanche-rosetta/blob/master/rosetta-cli-conf/testnet/avalanche.ros) (with prefunded account provided)
- Part of `check:spec` log
<img width="1192" alt="Screen Shot 2022-06-20 at 10 48 41 PM" src="https://user-images.githubusercontent.com/98374544/174725615-4c4fcf24-30e7-4f61-95c2-7b806e81bf54.png">

- Part of result
<img width="882" alt="Screen Shot 2022-06-20 at 10 48 52 PM" src="https://user-images.githubusercontent.com/98374544/174725454-6e7b5ece-59ed-4f0d-98ce-6462ae101975.png">

- Transaction is submitted and can be found in explorer
<img width="1210" alt="Screen Shot 2022-06-20 at 10 49 28 PM" src="https://user-images.githubusercontent.com/98374544/174725525-d060bd76-5efa-4b79-a0f3-af7d82e61020.png">

#### Account based: Optimism
<img width="1783" alt="Screen Shot 2022-06-20 at 11 02 25 PM" src="https://user-images.githubusercontent.com/98374544/174727353-e9e128ad-3e03-4c98-80d7-db5d452e6665.png">
<img width="915" alt="Screen Shot 2022-06-20 at 11 02 43 PM" src="https://user-images.githubusercontent.com/98374544/174727386-8218c93e-abc8-4b8b-a836-d22f337acba7.png">

