### PR TITLE
(nit) Update check_data long description to match docs

### DIFF
--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2020-2022 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,35 +32,35 @@ var (
 	checkDataCmd = &cobra.Command{
 		Use:   "check:data",
 		Short: "Check the correctness of a Rosetta Data API Implementation",
-		Long: `Check all server responses are properly constructed, that
-there are no duplicate blocks and transactions, that blocks can be processed
+		Long: `Check all server responses are 
+properly constructed, that there are no duplicate blocks and transactions, that blocks can be processed
 from genesis to the current block (re-orgs handled automatically), and that
 computed balance changes are equal to balance changes reported by the node.
-
+		
 When re-running this command, it will start where it left off if you specify
 some data directory. Otherwise, it will create a new temporary directory and start
 again from the genesis block. If you want to discard some number of blocks
-populate the start_index filed in the configuration file with some block index.
-Starting from a given index can be useful to debug a small range of blocks for
-issues but it is highly recommended you sync from start to finish to ensure
-all correctness checks are performed.
-
+populate the --start flag with some block index. Starting from a given index
+can be useful to debug a small range of blocks for issues but it is highly
+recommended you sync from start to finish to ensure all correctness checks
+are performed.
+		
 By default, account balances are looked up at specific heights (instead of
-only at the current block). If your node does not support this functionality,
-you can disable historical balance lookups in your configuration file. This will
-make reconciliation much less efficient but it will still work.
-
+only at the current block). If your node does not support this functionality
+set historical balance disabled to true. This will make reconciliation much
+less efficient but it will still work.
+		
 If check fails due to an INACTIVE reconciliation error (balance changed without
 any corresponding operation), the cli will automatically try to find the block
 missing an operation. If historical balance disabled is true, this automatic
 debugging tool does not work.
-
+		
 To debug an INACTIVE account reconciliation error without historical balance lookup,
 set the interesting accounts to the path of a JSON file containing
 accounts that will be actively checked for balance changes at each block. This
 will return an error at the block where a balance change occurred with no
 corresponding operations.
-
+		
 If your blockchain has a genesis allocation of funds and you set
 historical balance disabled to true, you must provide an
 absolute path to a JSON file containing initial balances with the

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 Coinbase, Inc.
+// Copyright 2022 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Motivation
Description text for check:data got updated in rosetta-api.org but not in the cmd file.

### Solution
Updated the text to match the text in rosetta-api.org
