### PR TITLE
ROSE-449: segregate coinbase spec requirements verification in check:spec

### DIFF
--- a/cmd/check_spec.go
+++ b/cmd/check_spec.go
@@ -28,10 +28,27 @@ import (
 var (
 	checkSpecCmd = &cobra.Command{
 		Use:   "check:spec",
-		Short: "Check a Rosetta implementation satisfies Rosetta spec",
-		Long: `Detailed Rosetta spec can be found in https://www.rosetta-api.org/docs/Reference.html.
-			Specifically, check:spec will examine the response from all data and construction API endpoints,
-			and verifiy they have required fields and the values are properly populated and formatted.`,
+		Short: "Check that a Rosetta implementation satisfies Rosetta spec",
+		Long: `Check:spec checks whether a Rosetta implementation satisfies either Coinbase-specific requirements or
+minimum requirements specified in rosetta-api.org.
+
+By default, check:spec will verify only Coinbase spec requirements. To verifiy the minimum requirements as well,
+add the --all flag to the check:spec command:
+
+rosetta-cli check:spec --all --configuration-file [filepath]
+		
+The minimum requirements verify whether an API response contains the required fields, and that the fields are 
+correctly formatted with proper values. For example, it would check whether the response of /network/list
+contains a list of network identifiers.
+		
+The Coinbase specific requirements are not documented in rosetta-api.org. However, we highly recommend that your
+implementation satisfies them. This ensures that, when you want to integrate your asset into the Coinbase platform,
+you can limit or eliminate implementation issues.
+		
+Here are a few examples of Coinbase spec requirements:
+1. The network_identifier in Rosetta configuration should be static. Network upgrade shouldn't change its value.
+2. When block_identifier is not specified, the call to /block endpoint should return the tip block.
+3. The online_url and offline_url should be different.`,
 		RunE: runCheckSpecCmd,
 	}
 )
@@ -93,27 +110,37 @@ func newCheckSpec(ctx context.Context) (*checkSpec, error) {
 }
 
 func (cs *checkSpec) networkOptions(ctx context.Context) checkSpecOutput {
-	printInfo("validating /network/options ...\n")
-	output := checkSpecOutput{
-		api: networkOptions,
-		validation: map[checkSpecRequirement]checkSpecStatus{
-			version:     checkSpecSuccess,
-			allow:       checkSpecSuccess,
-			offlineMode: checkSpecSuccess,
-		},
-	}
-	defer printInfo("/network/options validated\n")
+	if checkAllSpecs {
+		printInfo("validating /network/options ...\n")
+		output := checkSpecOutput{
+			api: networkOptions,
+			validation: map[checkSpecRequirement]checkSpecStatus{
+				version: {
+					status: checkSpecSuccess,
+				},
+				allow: {
+					status: checkSpecSuccess,
+				},
+				offlineMode: {
+					status: checkSpecSuccess,
+				},
+			},
+		}
+		defer printInfo("/network/options validated\n")
 
-	// NetworkOptionsRetry handles validation of /network/options response
-	// This is an endpoint for offline mode
-	_, err := cs.offlineFetcher.NetworkOptionsRetry(ctx, Config.Network, nil)
-	if err != nil {
-		printError("%v: unable to fetch network options\n", err.Err)
-		markAllValidationsFailed(output)
+		// NetworkOptionsRetry handles validation of /network/options response
+		// This is an endpoint for offline mode
+		_, err := cs.offlineFetcher.NetworkOptionsRetry(ctx, Config.Network, nil)
+		if err != nil {
+			printError("%v: unable to fetch network options\n", err.Err)
+			markAllValidationsFailed(output)
+			return output
+		}
+
 		return output
 	}
 
-	return output
+	return checkSpecOutput{}
 }
 
 func (cs *checkSpec) networkList(ctx context.Context) checkSpecOutput {
@@ -121,26 +148,38 @@ func (cs *checkSpec) networkList(ctx context.Context) checkSpecOutput {
 	output := checkSpecOutput{
 		api: networkList,
 		validation: map[checkSpecRequirement]checkSpecStatus{
-			networkIDs:      checkSpecSuccess,
-			offlineMode:     checkSpecSuccess,
-			staticNetworkID: checkSpecSuccess,
+			staticNetworkID: {
+				status:       checkSpecSuccess,
+				coinbaseSpec: true,
+			},
 		},
 	}
+
+	if checkAllSpecs {
+		output.validation[networkIDs] = checkSpecStatus{
+			status: checkSpecSuccess,
+		}
+		output.validation[offlineMode] = checkSpecStatus{
+			status: checkSpecSuccess,
+		}
+	}
+
 	defer printInfo("/network/list validated\n")
+	networks, err := cs.offlineFetcher.NetworkListRetry(ctx, nil)
 
 	// endpoint for offline mode
-	networks, err := cs.offlineFetcher.NetworkListRetry(ctx, nil)
 	if err != nil {
 		printError("%v: unable to fetch network list", err.Err)
 		markAllValidationsFailed(output)
 		return output
 	}
 
-	if len(networks.NetworkIdentifiers) == 0 {
+	if checkAllSpecs && len(networks.NetworkIdentifiers) == 0 {
 		printError("network_identifiers is required")
 		setValidationStatusFailed(output, networkIDs)
 	}
 
+	// static network ID
 	for _, network := range networks.NetworkIdentifiers {
 		if isEqual(network.Network, Config.Network.Network) &&
 			isEqual(network.Blockchain, Config.Network.Blockchain) {
@@ -148,50 +187,57 @@ func (cs *checkSpec) networkList(ctx context.Context) checkSpecOutput {
 		}
 	}
 
-	// static network ID
 	printError("network_identifier in configuration file is not returned by /network/list")
 	setValidationStatusFailed(output, staticNetworkID)
 	return output
 }
 
 func (cs *checkSpec) accountCoins(ctx context.Context) checkSpecOutput {
-	printInfo("validating /account/coins ...\n")
-	output := checkSpecOutput{
-		api: accountCoins,
-		validation: map[checkSpecRequirement]checkSpecStatus{
-			blockID: checkSpecSuccess,
-			coins:   checkSpecSuccess,
-		},
+	if checkAllSpecs {
+		printInfo("validating /account/coins ...\n")
+		output := checkSpecOutput{
+			api: accountCoins,
+			validation: map[checkSpecRequirement]checkSpecStatus{
+				blockID: {
+					status: checkSpecSuccess,
+				},
+				coins: {
+					status: checkSpecSuccess,
+				},
+			},
+		}
+		defer printInfo("/account/coins validated\n")
+
+		if isUTXO() {
+			acct, _, currencies, err := cs.getAccount(ctx)
+			if err != nil {
+				printError("%v: unable to get an account\n", err)
+				markAllValidationsFailed(output)
+				return output
+			}
+			if err != nil {
+				printError("%v\n", errAccountNullPointer)
+				markAllValidationsFailed(output)
+				return output
+			}
+
+			_, _, _, fetchErr := cs.onlineFetcher.AccountCoinsRetry(
+				ctx,
+				Config.Network,
+				acct,
+				false,
+				currencies)
+			if fetchErr != nil {
+				printError("%v: unable to get coins for account: %v\n", fetchErr.Err, *acct)
+				markAllValidationsFailed(output)
+				return output
+			}
+		}
+
+		return output
 	}
-	defer printInfo("/account/coins validated\n")
 
-	if isUTXO() {
-		acct, _, currencies, err := cs.getAccount(ctx)
-		if err != nil {
-			printError("%v: unable to get an account\n", err)
-			markAllValidationsFailed(output)
-			return output
-		}
-		if err != nil {
-			printError("%v\n", errAccountNullPointer)
-			markAllValidationsFailed(output)
-			return output
-		}
-
-		_, _, _, fetchErr := cs.onlineFetcher.AccountCoinsRetry(
-			ctx,
-			Config.Network,
-			acct,
-			false,
-			currencies)
-		if fetchErr != nil {
-			printError("%v: unable to get coins for account: %v\n", fetchErr.Err, *acct)
-			markAllValidationsFailed(output)
-			return output
-		}
-	}
-
-	return output
+	return checkSpecOutput{}
 }
 
 func (cs *checkSpec) block(ctx context.Context) checkSpecOutput {
@@ -199,11 +245,19 @@ func (cs *checkSpec) block(ctx context.Context) checkSpecOutput {
 	output := checkSpecOutput{
 		api: block,
 		validation: map[checkSpecRequirement]checkSpecStatus{
-			idempotent: checkSpecSuccess,
-			defaultTip: checkSpecSuccess,
+			defaultTip: {
+				status:       checkSpecSuccess,
+				coinbaseSpec: true,
+			},
 		},
 	}
 	defer printInfo("/block validated\n")
+
+	if checkAllSpecs {
+		output.validation[idempotent] = checkSpecStatus{
+			status: checkSpecSuccess,
+		}
+	}
 
 	res, fetchErr := cs.onlineFetcher.NetworkStatusRetry(ctx, Config.Network, nil)
 	if fetchErr != nil {
@@ -212,27 +266,29 @@ func (cs *checkSpec) block(ctx context.Context) checkSpecOutput {
 		return output
 	}
 
-	// multiple calls with the same hash should return the same block
-	var block *types.Block
-	tip := res.CurrentBlockIdentifier
-	callTimes := 3
+	if checkAllSpecs {
+		// multiple calls with the same hash should return the same block
+		var block *types.Block
+		tip := res.CurrentBlockIdentifier
+		callTimes := 3
 
-	for i := 0; i < callTimes; i++ {
-		blockID := types.PartialBlockIdentifier{
-			Hash: &tip.Hash,
-		}
-		b, fetchErr := cs.onlineFetcher.BlockRetry(ctx, Config.Network, &blockID)
-		if fetchErr != nil {
-			printError("%v: unable to fetch block %v\n", fetchErr.Err, blockID)
-			markAllValidationsFailed(output)
-			return output
-		}
+		for i := 0; i < callTimes; i++ {
+			blockID := types.PartialBlockIdentifier{
+				Hash: &tip.Hash,
+			}
+			b, fetchErr := cs.onlineFetcher.BlockRetry(ctx, Config.Network, &blockID)
+			if fetchErr != nil {
+				printError("%v: unable to fetch block %v\n", fetchErr.Err, blockID)
+				markAllValidationsFailed(output)
+				return output
+			}
 
-		if block == nil {
-			block = b
-		} else if !isEqual(types.Hash(*block), types.Hash(*b)) {
-			printError("%v\n", errBlockNotIdempotent)
-			setValidationStatusFailed(output, idempotent)
+			if block == nil {
+				block = b
+			} else if !isEqual(types.Hash(*block), types.Hash(*b)) {
+				printError("%v\n", errBlockNotIdempotent)
+				setValidationStatusFailed(output, idempotent)
+			}
 		}
 	}
 
@@ -243,11 +299,11 @@ func (cs *checkSpec) block(ctx context.Context) checkSpecOutput {
 		setValidationStatusFailed(output, defaultTip)
 		return output
 	}
-	tip = res.CurrentBlockIdentifier
+	tip := res.CurrentBlockIdentifier
 
 	// tip shoud be returned if block_identifier is not specified
 	emptyBlockID := &types.PartialBlockIdentifier{}
-	block, fetchErr = cs.onlineFetcher.BlockRetry(ctx, Config.Network, emptyBlockID)
+	block, fetchErr := cs.onlineFetcher.BlockRetry(ctx, Config.Network, emptyBlockID)
 	if fetchErr != nil {
 		printError("%v: unable to fetch tip block\n", fetchErr.Err)
 		setValidationStatusFailed(output, defaultTip)
@@ -264,51 +320,59 @@ func (cs *checkSpec) block(ctx context.Context) checkSpecOutput {
 }
 
 func (cs *checkSpec) errorObject(ctx context.Context) checkSpecOutput {
-	printInfo("validating error object ...\n")
-	output := checkSpecOutput{
-		api: errorObject,
-		validation: map[checkSpecRequirement]checkSpecStatus{
-			errorCode:    checkSpecSuccess,
-			errorMessage: checkSpecSuccess,
-		},
-	}
-	defer printInfo("error object validated\n")
+	if checkAllSpecs {
+		printInfo("validating error object ...\n")
+		output := checkSpecOutput{
+			api: errorObject,
+			validation: map[checkSpecRequirement]checkSpecStatus{
+				errorCode: {
+					status: checkSpecSuccess,
+				},
+				errorMessage: {
+					status: checkSpecSuccess,
+				},
+			},
+		}
+		defer printInfo("error object validated\n")
 
-	printInfo("%v\n", "sending request to /network/status ...")
-	emptyNetwork := &types.NetworkIdentifier{}
-	_, err := cs.onlineFetcher.NetworkStatusRetry(ctx, emptyNetwork, nil)
-	validateErrorObject(err, output)
-
-	printInfo("%v\n", "sending request to /network/options ...")
-	_, err = cs.onlineFetcher.NetworkOptionsRetry(ctx, emptyNetwork, nil)
-	validateErrorObject(err, output)
-
-	printInfo("%v\n", "sending request to /account/balance ...")
-	emptyAcct := &types.AccountIdentifier{}
-	emptyPartBlock := &types.PartialBlockIdentifier{}
-	emptyCur := []*types.Currency{}
-	_, _, _, err = cs.onlineFetcher.AccountBalanceRetry(ctx, emptyNetwork, emptyAcct, emptyPartBlock, emptyCur)
-	validateErrorObject(err, output)
-
-	if isUTXO() {
-		printInfo("%v\n", "sending request to /account/coins ...")
-		_, _, _, err = cs.onlineFetcher.AccountCoinsRetry(ctx, emptyNetwork, emptyAcct, false, emptyCur)
+		printInfo("%v\n", "sending request to /network/status ...")
+		emptyNetwork := &types.NetworkIdentifier{}
+		_, err := cs.onlineFetcher.NetworkStatusRetry(ctx, emptyNetwork, nil)
 		validateErrorObject(err, output)
-	} else {
-		printInfo("%v\n", "skip /account/coins for account based chain")
+
+		printInfo("%v\n", "sending request to /network/options ...")
+		_, err = cs.onlineFetcher.NetworkOptionsRetry(ctx, emptyNetwork, nil)
+		validateErrorObject(err, output)
+
+		printInfo("%v\n", "sending request to /account/balance ...")
+		emptyAcct := &types.AccountIdentifier{}
+		emptyPartBlock := &types.PartialBlockIdentifier{}
+		emptyCur := []*types.Currency{}
+		_, _, _, err = cs.onlineFetcher.AccountBalanceRetry(ctx, emptyNetwork, emptyAcct, emptyPartBlock, emptyCur)
+		validateErrorObject(err, output)
+
+		if isUTXO() {
+			printInfo("%v\n", "sending request to /account/coins ...")
+			_, _, _, err = cs.onlineFetcher.AccountCoinsRetry(ctx, emptyNetwork, emptyAcct, false, emptyCur)
+			validateErrorObject(err, output)
+		} else {
+			printInfo("%v\n", "skip /account/coins for account based chain")
+		}
+
+		printInfo("%v\n", "sending request to /block ...")
+		_, err = cs.onlineFetcher.BlockRetry(ctx, emptyNetwork, emptyPartBlock)
+		validateErrorObject(err, output)
+
+		printInfo("%v\n", "sending request to /block/transaction ...")
+		emptyTx := []*types.TransactionIdentifier{}
+		emptyBlock := &types.BlockIdentifier{}
+		_, err = cs.onlineFetcher.UnsafeTransactions(ctx, emptyNetwork, emptyBlock, emptyTx)
+		validateErrorObject(err, output)
+
+		return output
 	}
 
-	printInfo("%v\n", "sending request to /block ...")
-	_, err = cs.onlineFetcher.BlockRetry(ctx, emptyNetwork, emptyPartBlock)
-	validateErrorObject(err, output)
-
-	printInfo("%v\n", "sending request to /block/transaction ...")
-	emptyTx := []*types.TransactionIdentifier{}
-	emptyBlock := &types.BlockIdentifier{}
-	_, err = cs.onlineFetcher.UnsafeTransactions(ctx, emptyNetwork, emptyBlock, emptyTx)
-	validateErrorObject(err, output)
-
-	return output
+	return checkSpecOutput{}
 }
 
 // Searching for an account backwards from the tip

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,10 @@ var (
 	// logged to the console.
 	OnlyChanges bool
 
+	// allSpecs is a boolean indicating whether check:spec should verify only Coinbase
+	// spec requirements, or the minimum requirements as well.
+	checkAllSpecs bool
+
 	// If non-empty, used to validate that /network/options matches the contents of the file
 	// located at this path. The intended use case is someone previously ran
 	// utils:asserter-configuration `asserterConfigurationFile`, so the validation is being done
@@ -308,6 +312,12 @@ default values.`,
 	rootCmd.AddCommand(checkPerfCmd)
 
 	// check:spec
+	checkSpecCmd.Flags().BoolVar(
+		&checkAllSpecs,
+		"all",
+		false,
+		`Verify both minimum and Coinbase spec requirements`,
+	)
 	rootCmd.AddCommand(checkSpecCmd)
 }
 
@@ -397,6 +407,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.7.9")
+		fmt.Println("v0.8.0")
 	},
 }


### PR DESCRIPTION
ROSE-449: segregate coinbase spec requirements verification in check:spec

Fixes # .
There is no way to tell whether a requirement is Coinbase spec. Also we lack a way to switch b/w running coinbase spec validation and minimum verification (specified in rosetta-api.org).

### Solution
See PR for details.

### Test Evidence
1. Flag --help explains the purpose of check:spec
<img width="795" alt="Screen Shot 2022-07-12 at 12 09 06 PM" src="https://user-images.githubusercontent.com/93357037/178541765-fd70ba02-5a9e-4121-bcc2-ba55a201f72f.png">

2. By default only Coinbase spec validation will be run
<img width="911" alt="Screen Shot 2022-07-12 at 12 09 26 PM" src="https://user-images.githubusercontent.com/93357037/178541851-a7721f62-0ca6-4b28-b3ef-0867c39bb8c5.png">

3. Add a flag --all to run both Coinbase spec and minimum requirements 
<img width="896" alt="Screen Shot 2022-07-12 at 12 09 44 PM" src="https://user-images.githubusercontent.com/93357037/178541930-73654348-aa8e-4458-b152-471e0da9cec8.png">