### PR TITLE
Add separate config to disable balance pruning

### DIFF
--- a/configuration/types.go
+++ b/configuration/types.go
@@ -321,11 +321,15 @@ type DataConfiguration struct {
 	// the results of a check:data run.
 	ResultsOutputFile string `json:"results_output_file"`
 
-	// PruningDisabled is a bolean that indicates storage pruning should
+	// PruningDisabled is a boolean that indicates storage pruning should
 	// not be attempted. This should really only ever be set to true if you
 	// wish to use `start_index` at a later point to restart from some
 	// previously synced block.
 	PruningDisabled bool `json:"pruning_disabled"`
+
+	// PruningBalanceDisabled is a boolean that indicates balance pruning
+	// should not be attempted.
+	PruningBalanceDisabled bool `json:"pruning_balance_disabled"`
 
 	// PruningFrequency is the frequency (in seconds) that we attempt
 	// to prune blocks. If not populated, we use the default value

--- a/examples/configuration/default.json
+++ b/examples/configuration/default.json
@@ -39,6 +39,7 @@
   "status_port": 9090,
   "results_output_file": "",
   "pruning_disabled": false,
+  "pruning_balance_disabled": false,
   "initial_balance_fetch_disabled": false
  },
  "perf": null

--- a/pkg/processor/reconciler_helper.go
+++ b/pkg/processor/reconciler_helper.go
@@ -153,7 +153,7 @@ func (h *ReconcilerHelper) PruneBalances(
 	currency *types.Currency,
 	index int64,
 ) error {
-	if h.config.Data.PruningDisabled || h.config.Data.PruningBalanceDisabled {
+	if h.config.Data.PruningBalanceDisabled {
 		return nil
 	}
 

--- a/pkg/processor/reconciler_helper.go
+++ b/pkg/processor/reconciler_helper.go
@@ -153,7 +153,7 @@ func (h *ReconcilerHelper) PruneBalances(
 	currency *types.Currency,
 	index int64,
 ) error {
-	if h.config.Data.PruningDisabled {
+	if h.config.Data.PruningDisabled || h.config.Data.PruningBalanceDisabled {
 		return nil
 	}
 


### PR DESCRIPTION
### Motivation
We are experiencing a similar performance issue described in #316, when we are running `check:data` command.

We found that `PruneBalances` operation is the root culprit of the performance issue.
As you know, by default, the `PruneBalances` is called whenever a balance change happened for an account in a block. 
BTW, in some blockchains (like ICON), there is an account that is always included in every block (eg, `fee_treasury`), which makes only one reconcile goroutine is effectively active and the other goroutines that call `reconcileActiveAccounts` method would block on ` rosetta-sdk-go/storage/database.(*BadgerDatabase).WriteTransaction`.

### Solution
There is an existing config for disabling pruning, `PruningDisabled`.  But this config also applies to the state storage pruning.
We want to introduce a separate config only for balance pruning operation, named `PruningBalanceDisabled`.

### Open questions
None
