### PR TITLE
Indicate the current index when waiting to reach tip for `check:construction`

### DIFF
--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -368,7 +368,7 @@ func (t *ConstructionTester) StartPeriodicLogger(
 	}
 }
 
-func (t *ConstructionTester) checkTip(ctx context.Context) (int64, error) {
+func (t *ConstructionTester) checkTip(ctx context.Context) (int64, int64, error) {
 	atTip, blockIdentifier, err := utils.CheckNetworkTip(
 		ctx,
 		t.network,
@@ -376,14 +376,14 @@ func (t *ConstructionTester) checkTip(ctx context.Context) (int64, error) {
 		t.onlineFetcher,
 	)
 	if err != nil {
-		return -1, fmt.Errorf("failed to check network tip: %w", err)
+		return -1, 0, fmt.Errorf("failed to check network tip: %w", err)
 	}
 
 	if atTip {
-		return blockIdentifier.Index, nil
+		return blockIdentifier.Index, 0, nil
 	}
 
-	return -1, nil
+	return -1, blockIdentifier.Index, nil
 }
 
 // waitForTip loops until the Rosetta implementation is at tip.
@@ -393,7 +393,7 @@ func (t *ConstructionTester) waitForTip(ctx context.Context) (int64, error) {
 
 	for {
 		// Don't wait any time before first tick if at tip.
-		tipIndex, err := t.checkTip(ctx)
+		tipIndex, currentIndex, err := t.checkTip(ctx)
 		if err != nil {
 			return -1, fmt.Errorf("failed to check tip: %w", err)
 		}
@@ -402,7 +402,7 @@ func (t *ConstructionTester) waitForTip(ctx context.Context) (int64, error) {
 			return tipIndex, nil
 		}
 
-		log.Println("waiting for implementation to reach tip before testing...")
+		log.Printf("waiting for implementation to reach tip before testing... (current index: %d, tip delay: %d)\n", currentIndex, t.config.TipDelay)
 
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
### Motivation
When trying to run `check:construction` I was constantly getting the `waiting for implementation to reach tip before testing...` message but couldn't tell if any progress was made. After a while I stopped it thinking I was stuck in a loop when I was just syncing super slowly.

### Solution
Add the current index and tip delay info to the message which show how we are progressing.

see
```
2022/10/13 10:17:53 waiting for implementation to reach tip before testing... (current index: 12590068, tip delay: 50000)
[MEMORY] Heap: 1103.031822MB Stack: 0.656250MB System: 1160.784706MB GCs: 6
2022/10/13 10:18:03 waiting for implementation to reach tip before testing... (current index: 12590100, tip delay: 50000)
[MEMORY] Heap: 1103.045753MB Stack: 0.656250MB System: 1160.784706MB GCs: 6
2022/10/13 10:18:13 waiting for implementation to reach tip before testing... (current index: 12590139, tip delay: 50000)
[MEMORY] Heap: 1103.075333MB Stack: 0.656250MB System: 1160.784706MB GCs: 6
```

