### PR TITLE
[fix] bootstrap balances should be done only for genesis block testing

### DIFF
--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -345,7 +345,12 @@ func InitializeData(
 		//
 		// We need to do this after instantiating the balance storage handler
 		// because it is invoked within BootstrapBalances.
-		if len(config.Data.BootstrapBalances) > 0 {
+		//
+		// We only need to bootstrap balances when we run this test from
+		// genesis block. If it is not genesis block, we use the balances from
+		// previous block
+		if (config.Data.StartIndex == nil || *config.Data.StartIndex == genesisBlock.Index) &&
+			len(config.Data.BootstrapBalances) > 0 {
 			_, err := blockStorage.GetHeadBlockIdentifier(ctx)
 			switch {
 			case err == storageErrs.ErrHeadBlockNotFound:

--- a/pkg/tester/general.go
+++ b/pkg/tester/general.go
@@ -28,6 +28,9 @@ const (
 	// MemoryLoggingFrequency is the frequency that memory
 	// usage stats are logged to the terminal.
 	MemoryLoggingFrequency = 10 * time.Second
+
+	// ReadHeaderTimeout is the header timeout for server
+	ReadHeaderTimeout = 5 * time.Second
 )
 
 // LogMemoryLoop runs a loop that logs memory usage.
@@ -57,8 +60,9 @@ func StartServer(
 	port uint,
 ) error {
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
-		Handler: handler,
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           handler,
+		ReadHeaderTimeout: ReadHeaderTimeout,
 	}
 
 	go func() {


### PR DESCRIPTION
Fixes # .

### Motivation
When we run parallel validation from any block other then genesis, we are using `bootstrap_balances.json` to initialize balances which results into balance mismatch because actual balances in `n-1` block might have been updated and we need to use that.

### Solution
Add a condition to validation that, bootstrap balances only if `startIndex` is empty or is genesis block.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
