### PR TITLE
Make status port configurable via command line args

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -332,6 +332,13 @@ default values.`,
 		"requestUUID configures the requestUUID in logs, which aims to enable search logs by requestUUID",
 	)
 
+	checkConstructionCmd.Flags().UintVar(
+		&statusPort,
+		"status-port",
+		0,
+		"status-port configures the status query port, this will override the status_port",
+	)
+
 	rootCmd.AddCommand(checkConstructionCmd)
 
 	// View Commands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ var (
 	inMemoryMode           bool
 	tableSize              int64
 	requestUUID            string
+	statusPort			   uint
 
 	// Config is the populated *configuration.Configuration from
 	// the configurationFile. If none is provided, this is set
@@ -288,6 +289,13 @@ default values.`,
 		"requestUUID configures the requestUUID in logs, which aims to enable search logs by requestUUID",
 	)
 
+	checkDataCmd.Flags().UintVar(
+		&statusPort,
+		"status-port",
+		0,
+		"status-port configures the status query port, this will override the status_port",
+	)
+
 	rootCmd.AddCommand(checkDataCmd)
 	checkConstructionCmd.Flags().StringVar(
 		&asserterConfigurationFile,
@@ -418,6 +426,10 @@ func initConfig() {
 
 	if len(requestUUID) != 0 {
 		Config.RequestUUID = requestUUID
+	}
+
+	if statusPort > 0 {
+		Config.Data.StatusPort = statusPort
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -437,6 +437,9 @@ func initConfig() {
 
 	if statusPort > 0 {
 		Config.Data.StatusPort = statusPort
+		if Config.Construction != nil {
+			Config.Construction.StatusPort = statusPort
+		}
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ var (
 	inMemoryMode           bool
 	tableSize              int64
 	requestUUID            string
-	statusPort			   uint
+	statusPort             uint
 
 	// Config is the populated *configuration.Configuration from
 	// the configurationFile. If none is provided, this is set

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -57,8 +57,7 @@ func DefaultPerfConfiguration() *CheckPerfConfiguration {
 }
 
 // DefaultConfiguration returns a *Configuration with the
-// EthereumNetwork, DefaultURL, DefaultTimeout,
-// DefaultConstructionConfiguration and DefaultDataConfiguration.
+// EthereumNetwork, DefaultURL, DefaultTimeout, and DefaultDataConfiguration.
 func DefaultConfiguration() *Configuration {
 	return &Configuration{
 		Network:              EthereumNetwork,


### PR DESCRIPTION
Fixes # .

### Motivation
We need to make status port configurable via command line, so we can run multiple rosetta-cli with status server enabled in same host.

### Solution
Support command line args in root.go
Tested with
```
go run . --configuration-file config.json check:data --start-block 1 --end-block 1000 --status-port 9094
```

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
