### PR TITLE
init customized info

### DIFF
--- a/cmd/check_construction.go
+++ b/cmd/check_construction.go
@@ -149,6 +149,7 @@ func runCheckConstructionCmd(_ *cobra.Command, _ []string) error {
 
 	g, ctx := errgroup.WithContext(ctx)
 	ctx = logger.AddRequestUUIDToContext(ctx, Config.RequestUUID)
+	ctx = logger.AddInfoMetaDataToContext(ctx, Config.InfoMetaData)
 
 	g.Go(func() error {
 		return constructionTester.StartPeriodicLogger(ctx)

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -156,6 +156,7 @@ func runCheckDataCmd(_ *cobra.Command, _ []string) error {
 
 	g, ctx := errgroup.WithContext(ctx)
 	ctx = logger.AddRequestUUIDToContext(ctx, Config.RequestUUID)
+	ctx = logger.AddInfoMetaDataToContext(ctx, Config.InfoMetaData)
 	
 	g.Go(func() error {
 		return dataTester.StartPeriodicLogger(ctx)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,7 @@ var (
 	tableSize              int64
 	requestUUID            string
 	statusPort             uint
+	InfoMetaData           string
 
 	// Config is the populated *configuration.Configuration from
 	// the configurationFile. If none is provided, this is set
@@ -289,6 +290,13 @@ default values.`,
 		"requestUUID configures the requestUUID in logs, which aims to enable search logs by requestUUID",
 	)
 
+	checkDataCmd.Flags().StringVar(
+		&InfoMetaData,
+		"info-metadata",
+		"",
+		"metadata configures the metadata which aims to show in logs",
+	)
+
 	checkDataCmd.Flags().UintVar(
 		&statusPort,
 		"status-port",
@@ -440,6 +448,10 @@ func initConfig() {
 		if Config.Construction != nil {
 			Config.Construction.StatusPort = statusPort
 		}
+	}
+
+	if len(InfoMetaData) != 0 {
+		Config.InfoMetaData = InfoMetaData	
 	}
 }
 

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -461,6 +461,10 @@ type Configuration struct {
 	// then this value must be true.
 	CoinSupported bool `json:"coin_supported"`
 
+	// InfoMetaData is a map of key:value
+	// which aims to show in the log for search
+	InfoMetaData string `json:"info_metadata,omitempty"`
+
 	Construction *ConstructionConfiguration `json:"construction"`
 	Data         *DataConfiguration         `json:"data"`
 	Perf         *CheckPerfConfiguration    `json:"perf"`

--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -115,6 +115,7 @@ func InitializeConstruction(
 	}
 
 	counterStorage := modules.NewCounterStorage(localStore)
+	logInfoMetaData := logger.ConvertStringToMap(config.InfoMetaData)
 	logger, err := logger.NewLogger(
 		dataPath,
 		false,
@@ -124,6 +125,7 @@ func InitializeConstruction(
 		logger.Construction,
 		network,
 		config.RequestUUID,
+		logInfoMetaData,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize logger with error: %w", err)

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -232,6 +232,7 @@ func InitializeData(
 	blockStorage := modules.NewBlockStorage(localStore, config.SerialBlockWorkers)
 	balanceStorage := modules.NewBalanceStorage(localStore)
 
+	logInfoMetaData := logger.ConvertStringToMap(config.InfoMetaData)
 	logger, err := logger.NewLogger(
 		dataPath,
 		config.Data.LogBlocks,
@@ -241,6 +242,7 @@ func InitializeData(
 		logger.Data,
 		network,
 		config.RequestUUID,
+		logInfoMetaData,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize logger with error: %w", err)
@@ -1089,6 +1091,7 @@ func (t *DataTester) recursiveOpSearch(
 		logger.Data,
 		t.network,
 		EmptyRequestUUID,
+		nil,
 	)
 
 	if err != nil {


### PR DESCRIPTION
Fixes # .

added a new field/key to enable users to record customized key:value 
which could make searching log easier, eg: search by cli-x

<img width="1294" alt="Screenshot 2023-01-06 at 3 41 02 PM" src="https://user-images.githubusercontent.com/96205264/211118226-8b240e95-9cb2-4a1f-9271-9c86878b0af7.png">

<img width="1303" alt="Screenshot 2023-01-06 at 3 42 08 PM" src="https://user-images.githubusercontent.com/96205264/211118232-1c767cf7-e629-4d23-8aa4-95d3657b2001.png">



### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
