### PR TITLE
bump up to 0.10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 WORKDIR /go/src
 
-ARG VERSION=v0.10.1
+ARG VERSION=v0.10.2
 RUN git clone https://github.com/coinbase/rosetta-cli.git && \
 	cd rosetta-cli && \
 	git fetch --all --tags && \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -488,6 +488,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print rosetta-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.10.1")
+		fmt.Println("v0.10.2")
 	},
 }

--- a/pkg/processor/balance_storage_helper.go
+++ b/pkg/processor/balance_storage_helper.go
@@ -69,8 +69,9 @@ func NewBalanceStorageHelper(
 		// by this, all the Currencies in this address will be skipped
 		if account.Currency == nil {
 			exemptMap[account.Account.Address] = struct{}{}
+		} else {
+			exemptMap[types.Hash(account)] = struct{}{}
 		}
-		exemptMap[types.Hash(account)] = struct{}{}
 	}
 
 	return &BalanceStorageHelper{

--- a/pkg/processor/balance_storage_helper.go
+++ b/pkg/processor/balance_storage_helper.go
@@ -65,6 +65,9 @@ func NewBalanceStorageHelper(
 	// Pre-process exemptAccounts on initialization
 	// to provide fast lookup while syncing.
 	for _, account := range exemptAccounts {
+		if account.Currency == nil {
+			exemptMap[account.Account.Address] =struct{}{}
+		}
 		exemptMap[types.Hash(account)] = struct{}{}
 	}
 
@@ -151,7 +154,8 @@ func (h *BalanceStorageHelper) ExemptFunc() parser.ExemptOperation {
 		})
 
 		_, exists := h.exemptAccounts[thisAcct]
-		return exists
+		_, existsAddress := h.exemptAccounts[op.Account.Address]
+		return exists || existsAddress
 	}
 }
 

--- a/pkg/processor/balance_storage_helper.go
+++ b/pkg/processor/balance_storage_helper.go
@@ -150,18 +150,20 @@ func (h *BalanceStorageHelper) ExemptFunc() parser.ExemptOperation {
 				return true
 			}
 		}
+		// if exemptAccounts have the Account address means all the 
+		// currencies in this Account address need to be skipped
+		_, existsAddress := h.exemptAccounts[op.Account.Address]
+		if existsAddress {
+			return existsAddress
+		} 
 
 		thisAcct := types.Hash(&types.AccountCurrency{
 			Account:  op.Account,
 			Currency: op.Amount.Currency,
 		})
 
-		// if exemptAccounts have the hash of AccountCurrency or the Account address
-		// return true, as if exemptAccounts have the Account address means all the 
-		// currencies in this Account address need to be skipped
 		_, exists := h.exemptAccounts[thisAcct]
-		_, existsAddress := h.exemptAccounts[op.Account.Address]
-		return exists || existsAddress
+		return exists
 	}
 }
 

--- a/pkg/processor/balance_storage_helper.go
+++ b/pkg/processor/balance_storage_helper.go
@@ -65,8 +65,10 @@ func NewBalanceStorageHelper(
 	// Pre-process exemptAccounts on initialization
 	// to provide fast lookup while syncing.
 	for _, account := range exemptAccounts {
+		// if users do not specify Currency, we added the address 
+		// by this, all the Currencies in this address will be skipped
 		if account.Currency == nil {
-			exemptMap[account.Account.Address] =struct{}{}
+			exemptMap[account.Account.Address] = struct{}{}
 		}
 		exemptMap[types.Hash(account)] = struct{}{}
 	}
@@ -153,6 +155,9 @@ func (h *BalanceStorageHelper) ExemptFunc() parser.ExemptOperation {
 			Currency: op.Amount.Currency,
 		})
 
+		// if exemptAccounts have the hash of AccountCurrency or the Account address
+		// return true, if exemptAccounts have the Account address means all the 
+		// currencies in this account need to be skipped
 		_, exists := h.exemptAccounts[thisAcct]
 		_, existsAddress := h.exemptAccounts[op.Account.Address]
 		return exists || existsAddress

--- a/pkg/processor/balance_storage_helper.go
+++ b/pkg/processor/balance_storage_helper.go
@@ -65,7 +65,7 @@ func NewBalanceStorageHelper(
 	// Pre-process exemptAccounts on initialization
 	// to provide fast lookup while syncing.
 	for _, account := range exemptAccounts {
-		// if users do not specify Currency, we added the address 
+		// if users do not specify Currency, we add the address 
 		// by this, all the Currencies in this address will be skipped
 		if account.Currency == nil {
 			exemptMap[account.Account.Address] = struct{}{}
@@ -156,8 +156,8 @@ func (h *BalanceStorageHelper) ExemptFunc() parser.ExemptOperation {
 		})
 
 		// if exemptAccounts have the hash of AccountCurrency or the Account address
-		// return true, if exemptAccounts have the Account address means all the 
-		// currencies in this account need to be skipped
+		// return true, as if exemptAccounts have the Account address means all the 
+		// currencies in this Account address need to be skipped
 		_, exists := h.exemptAccounts[thisAcct]
 		_, existsAddress := h.exemptAccounts[op.Account.Address]
 		return exists || existsAddress


### PR DESCRIPTION
Fixes # .

this pr combine two things:

1. enable a new logic in loading accounts, 
   if the accounts do not have a currency, cli will loading all the currencies in this account by loading its address
2. bump up version
   this version enables customized metadata, bump up version helps us using it in test-runner

tests:
did two paris of tests:
1.1 failed at 7849512
 
<img width="1232" alt="Screenshot 2023-01-17 at 4 25 53 PM" src="https://user-images.githubusercontent.com/96205264/213090591-3d936741-bd11-46bc-82c2-b5d5e69c86a5.png">

1.2 adding this account address only and passed 7849512
<img width="675" alt="Screenshot 2023-01-17 at 4 29 22 PM" src="https://user-images.githubusercontent.com/96205264/213090701-61c35010-37b9-4029-abe4-16f2a5299447.png">

<img width="1199" alt="Screenshot 2023-01-17 at 4 32 47 PM" src="https://user-images.githubusercontent.com/96205264/213092623-c1725e44-a6d0-45c4-b13b-dd10a6d5b6af.png">


2.1 failed at 7849539, 

<img width="1235" alt="Screenshot 2023-01-17 at 6 29 51 PM" src="https://user-images.githubusercontent.com/96205264/213090810-ac9ee258-6a44-4645-a165-67f7a57e61f1.png">

2.2 passed by adding this address
<img width="704" alt="Screenshot 2023-01-17 at 6 17 14 PM" src="https://user-images.githubusercontent.com/96205264/213090953-e7ad045f-7b31-4a16-ad41-f21a762e0183.png">
<img width="582" alt="Screenshot 2023-01-17 at 6 17 32 PM" src="https://user-images.githubusercontent.com/96205264/213090961-720af312-79d3-4802-b4a9-19b738a49aa5.png">


### Motivation
<!--


Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
