### PR TITLE
Add signature verification tool in rosetta-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Example: To validate that the Data API implementation is correct, running the fo
 docker run -v "$(pwd):/data" -it [image-name] check:data --configuration-file /data/config.json
 ```
 
+## Key Sign Tool
+Rosetta CLI comes with a handy key sign tool for local testing. Please refer to this [README](./cmd/README.md) on how to use it.
+
 ## Updates and Releases
 
 We recommend that you continually update your installation to the latest release as soon as possible. The latest release notes are available in our [Community](https://community.rosetta-api.org) board under the [Release](https://community.rosetta-api.org/c/releases/13) category.

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,0 +1,33 @@
+## Key Sign Tool
+
+Rosetta CLI has a key sign tool, which you can use to sign and verify various curves supported
+by rosetta-specifications. This should only be used for local development. Never share private keys anywhere.
+
+### Usage
+#### Sign
+```
+rosetta-cli key:sign --configuration-file config.json
+```
+
+A sample config file is located [here](../examples/configuration/sign.json)
+
+Required fields includes
+- `pub_key`
+- `private_key`
+- `signing_payload`
+
+
+#### Verify
+```
+rosetta-cli key:verify --configuration-file config.json
+```
+A sample config file is located [here](../examples/configuration/sign.json)
+
+Required fields includes
+- `pub_key`
+- `signing_payload`
+- `signature`
+
+
+### Troubleshoot
+- `account_identifier` field in `signing_payload` field should've a dummy address for providing valid payload.

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -19,9 +19,9 @@ Required fields includes
 
 #### Verify
 ```
-rosetta-cli key:verify --configuration-file config.json
+rosetta-cli key:verify --configuration-file verify.json
 ```
-A sample config file is located [here](../examples/configuration/sign.json)
+A sample config file is located [here](../examples/configuration/verify.json)
 
 Required fields includes
 - `pub_key`

--- a/cmd/key_verify.go
+++ b/cmd/key_verify.go
@@ -1,0 +1,69 @@
+// Copyright 2023 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"github.com/coinbase/rosetta-sdk-go/keys"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	keyVerifyCmd = &cobra.Command{
+		Use:   "key:verify",
+		Short: "Verify the signature using the public key",
+		Long: `Verify the signature using the public key
+				It supports Keypair specified by https://github.com/coinbase/rosetta-specifications`,
+		RunE: runKeyVerifyCmd,
+	}
+)
+
+func runKeyVerifyCmd(_ *cobra.Command, _ []string) error {
+	if Config.Sign == nil {
+		return errors.New("sign configuration is missing")
+	}
+
+	if len(Config.Sign.Signature.Bytes) == 0 ||
+		Config.Sign.SigningPayload == nil ||
+		Config.Sign.SigningPayload.SignatureType == "" ||
+		Config.Sign.PubKey == nil {
+		color.Red("invalid verify input")
+	}
+
+	keyPair := keys.KeyPair{
+		PublicKey: Config.Sign.PubKey,
+	}
+
+	signer, err := keyPair.Signer()
+	if err != nil {
+		color.Red("signer invalid with err %#v", err)
+		return err
+	}
+
+	signature := Config.Sign.Signature
+	signature.SignatureType = Config.Sign.SigningPayload.SignatureType
+	signature.SigningPayload = Config.Sign.SigningPayload
+	signature.PublicKey = Config.Sign.PubKey
+
+	err = signer.Verify(signature)
+	if err != nil {
+		color.Red("invalid signature with err %#v", err)
+		return err
+	}
+
+	color.Green("Signature Verified.")
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -376,8 +376,11 @@ default values.`,
 	)
 	rootCmd.AddCommand(checkSpecCmd)
 
-	// Sign command
-	rootCmd.AddCommand(signCmd)
+	// Key Sign command
+	rootCmd.AddCommand(keySignCmd)
+
+	// Key Verify command
+	rootCmd.AddCommand(keyVerifyCmd)
 }
 
 func initConfig() {

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -482,7 +482,7 @@ type SignConfiguration struct {
 	PubKey         *types.PublicKey      `json:"pub_key"`
 	PrivateKey     string                `json:"private_key"`
 	SigningPayload *types.SigningPayload `json:"signing_payload"`
-	Signature     *types.Signature      `json:"signature,omitempty"`
+	Signature      *types.Signature      `json:"signature,omitempty"`
 }
 
 // CheckPerfConfiguration configuration for check perf

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -482,6 +482,7 @@ type SignConfiguration struct {
 	PubKey         *types.PublicKey      `json:"pub_key"`
 	PrivateKey     string                `json:"private_key"`
 	SigningPayload *types.SigningPayload `json:"signing_payload"`
+	Signature     *types.Signature      `json:"signature,omitempty"`
 }
 
 // CheckPerfConfiguration configuration for check perf

--- a/examples/configuration/sign.json
+++ b/examples/configuration/sign.json
@@ -7,7 +7,13 @@
     "private_key": "",
     "signing_payload": {
       "hex_bytes": "370e74254e8cbaa343af3564901456082ec7af967e45ff24ba061233b1a1b04f",
-      "signature_type": "ecdsa"
+      "signature_type": "ecdsa",
+      "account_identifier": {
+        "address": "dummy"
+      }
+    },
+    "signature": {
+      "hex_bytes": "c80547470b7e4d3fc17c988b2244dfebc909b3e9f7fd0c1387763263cc70d16d24f326b9c12ba2ea278164c0b30f128a809585fc503eda43de429aadb9f893ef"
     }
   }
 }

--- a/examples/configuration/verify.json
+++ b/examples/configuration/verify.json
@@ -4,13 +4,15 @@
       "curve_type": "secp256k1",
       "hex_bytes": "03c7e625aa08cad8f257d9ee2b9b7a0214f19f981afd5b498c728ad7ed6c0c3df6"
     },
-    "private_key": "",
     "signing_payload": {
       "hex_bytes": "370e74254e8cbaa343af3564901456082ec7af967e45ff24ba061233b1a1b04f",
       "signature_type": "ecdsa",
       "account_identifier": {
         "address": "dummy"
       }
+    },
+    "signature": {
+      "hex_bytes": "c80547470b7e4d3fc17c988b2244dfebc909b3e9f7fd0c1387763263cc70d16d24f326b9c12ba2ea278164c0b30f128a809585fc503eda43de429aadb9f893ef"
     }
   }
 }


### PR DESCRIPTION
Fixes # .

### Motivation
- We need a tool to sign and verify for local development

### Solution
- Add verify tool
- Rename tool command to `key:sign` and `key:verify`
- Add Readme

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
