### PR TITLE
Adjust install script to handle new repository name

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,13 +20,13 @@ set -e
 usage() {
   this=$1
   cat <<EOF
-$this: download go binaries for coinbase/rosetta-cli
+$this: download go binaries for coinbase/mesh-cli
 
 Usage: $this [-b] bindir [-d] [tag]
   -b sets bindir or installation directory, Defaults to ./bin
   -d turns on debug logging
    [tag] is a tag from
-   https://github.com/coinbase/rosetta-cli/releases
+   https://github.com/coinbase/mesh-cli/releases
    If tag is missing, then the latest will be used.
 
 EOF
@@ -300,7 +300,7 @@ EOF
 BINARY=rosetta-cli
 FORMAT=tar.gz
 OWNER=coinbase
-REPO="rosetta-cli"
+REPO="mesh-cli"
 OS=$(uname_os)
 ARCH=$(uname_arch)
 PREFIX="$OWNER/$REPO"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

Some time ago, the repository `rosetta-cli` has been renamed to `mesh-cli`. Since recently, the old URL of the repository does not redirect to the new one (perhaps the GitHub redirect policy expired):
 - https://github.com/coinbase/rosetta-cli (page not found)

Thus, `script/install.sh` fails to work properly.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Apply minimal adjustments to `scripts/install.sh`, so that installation flow is recovered.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
