### PR TITLE
feat: Rename cli to mesh-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 rosetta-cli
+mesh-cli
 bin/
 /.vscode
 /cli-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 # Compile golang
-FROM ubuntu:20.04 as cli
+FROM ubuntu:24.04 as cli
 
 RUN apt-get update && apt-get install -y curl make gcc g++ git
-ENV GOLANG_VERSION 1.17.9
+ENV GOLANG_VERSION 1.24.8
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6
+ENV GOLANG_DOWNLOAD_SHA256 6842c516ca66c89d648a7f1dbe28e28c47b61b59f8f06633eb2ceb1188e9251d
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
   && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
@@ -31,14 +31,15 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 WORKDIR /go/src
 
-ARG VERSION=v0.10.4
-RUN git clone https://github.com/coinbase/rosetta-cli.git && \
-	cd rosetta-cli && \
+ARG VERSION=v0.11.0
+RUN git clone https://github.com/coinbase/mesh-cli.git && \
+	cd mesh-cli && \
 	git fetch --all --tags && \
 	git checkout $VERSION && \
-	make install
+	make install && \
+	cp /go/bin/mesh-cli /go/bin/rosetta-cli
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN apt-get update -y && apt-get install -y \
 	curl
@@ -47,4 +48,4 @@ RUN apt-get update -y && apt-get install -y \
 COPY --from=cli /go/bin/ /usr/local/bin/
 
 WORKDIR /app
-ENTRYPOINT ["rosetta-cli"]
+ENTRYPOINT ["mesh-cli"]

--- a/cmd/check_construction.go
+++ b/cmd/check_construction.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 	"time"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
-	"github.com/coinbase/rosetta-cli/pkg/logger"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
+	"github.com/coinbase/mesh-cli/pkg/logger"
 	"github.com/fatih/color"
 
-	"github.com/coinbase/rosetta-cli/pkg/results"
-	"github.com/coinbase/rosetta-cli/pkg/tester"
+	"github.com/coinbase/mesh-cli/pkg/results"
+	"github.com/coinbase/mesh-cli/pkg/tester"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -46,7 +46,7 @@ are run to ensure that intermediate representations are correct (for example, do
 an unsigned transaction return a superset of operations provided during
 construction?).
 
-Check out the https://github.com/coinbase/rosetta-cli/tree/master/examples
+Check out the https://github.com/coinbase/mesh-cli/tree/master/examples
 directory for examples of how to configure this test for Bitcoin and
 Ethereum.
 

--- a/cmd/check_data.go
+++ b/cmd/check_data.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coinbase/rosetta-cli/pkg/logger"
-	"github.com/coinbase/rosetta-cli/pkg/results"
-	"github.com/coinbase/rosetta-cli/pkg/tester"
+	"github.com/coinbase/mesh-cli/pkg/logger"
+	"github.com/coinbase/mesh-cli/pkg/results"
+	"github.com/coinbase/mesh-cli/pkg/tester"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/coinbase/rosetta-sdk-go/utils"

--- a/cmd/check_perf.go
+++ b/cmd/check_perf.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coinbase/rosetta-cli/pkg/results"
-	t "github.com/coinbase/rosetta-cli/pkg/tester"
+	"github.com/coinbase/mesh-cli/pkg/results"
+	t "github.com/coinbase/mesh-cli/pkg/tester"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )

--- a/cmd/check_spec.go
+++ b/cmd/check_spec.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coinbase/rosetta-cli/pkg/results"
+	"github.com/coinbase/mesh-cli/pkg/results"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/spf13/cobra"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 )
 
 var (
@@ -37,7 +37,7 @@ minimum requirements specified in rosetta-api.org.
 By default, check:spec will verify only Coinbase spec requirements. To verify the minimum requirements as well,
 add the --all flag to the check:spec command:
 
-rosetta-cli check:spec --all --configuration-file [filepath]
+mesh-cli check:spec --all --configuration-file [filepath]
 		
 The minimum requirements verify whether an API response contains the required fields, and that the fields are 
 correctly formatted with proper values. For example, it would check whether the response of /network/list

--- a/cmd/check_spec_utils.go
+++ b/cmd/check_spec_utils.go
@@ -21,7 +21,7 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/fatih/color"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 )
 
 type checkSpecAPI string

--- a/cmd/configuration_create.go
+++ b/cmd/configuration_create.go
@@ -17,7 +17,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/coinbase/rosetta-cli/configuration"
+	"github.com/coinbase/mesh-cli/configuration"
 
 	"github.com/coinbase/rosetta-sdk-go/utils"
 	"github.com/spf13/cobra"

--- a/cmd/configuration_validate.go
+++ b/cmd/configuration_validate.go
@@ -17,7 +17,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/coinbase/rosetta-cli/configuration"
+	"github.com/coinbase/mesh-cli/configuration"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/coinbase/rosetta-sdk-go/types"
 	"log"
 	"os"
 	"os/signal"
@@ -26,7 +25,9 @@ import (
 	"runtime/pprof"
 	"syscall"
 
-	"github.com/coinbase/rosetta-cli/configuration"
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/coinbase/mesh-cli/configuration"
 
 	"github.com/coinbase/rosetta-sdk-go/utils"
 	"github.com/fatih/color"
@@ -40,7 +41,7 @@ const (
 
 var (
 	rootCmd = &cobra.Command{
-		Use:               "rosetta-cli",
+		Use:               "mesh-cli",
 		Short:             "CLI for the Rosetta API",
 		PersistentPreRunE: rootPreRun,
 	}
@@ -104,7 +105,7 @@ var (
 	// and check:construction.
 	asserterConfigurationFile string
 
-	// curveType is used to specify curve type to generate a keypair using rosetta-cli key:gen
+	// curveType is used to specify curve type to generate a keypair using mesh-cli key:gen
 	// command
 	curveType string
 )
@@ -187,7 +188,7 @@ func rootPostRun() {
 }
 
 // Execute handles all invocations of the
-// rosetta-cli cmd.
+// mesh-cli cmd.
 func Execute() error {
 	defer rootPostRun()
 	return rootCmd.Execute()
@@ -203,7 +204,7 @@ func init() {
 		"",
 		`Configuration file that provides connection and test settings.
 If you would like to generate a starter configuration file (populated
-with the defaults), run rosetta-cli configuration:create.
+with the defaults), run mesh-cli configuration:create.
 
 Any fields not populated in the configuration file will be populated with
 default values.`,
@@ -440,7 +441,7 @@ func initConfig() {
 	// Override start and end syncing index in configuration file when it's explicitly set via CLI
 	if startIndex != -1 {
 		Config.Data.StartIndex = &startIndex
-		// Configures rosetta-cli to lookup the balance of newly seen accounts at the
+		// Configures mesh-cli to lookup the balance of newly seen accounts at the
 		// parent block before applying operations. Otherwise the balance will be 0.
 		Config.Data.InitialBalanceFetchDisabled = false
 	}
@@ -518,8 +519,8 @@ func handleSignals(listeners *[]context.CancelFunc) {
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print rosetta-cli version",
+	Short: "Print mesh-cli version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.10.4")
+		fmt.Println("v0.11.0")
 	},
 }

--- a/cmd/validate_asserter_config.go
+++ b/cmd/validate_asserter_config.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"

--- a/cmd/view_block.go
+++ b/cmd/view_block.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"time"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/parser"

--- a/cmd/view_networks.go
+++ b/cmd/view_networks.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/coinbase/rosetta-cli/pkg/errors"
+	"github.com/coinbase/mesh-cli/pkg/errors"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -23,7 +23,7 @@ import (
 	"runtime"
 	"strings"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/constructor/dsl"
 	"github.com/coinbase/rosetta-sdk-go/constructor/job"
@@ -367,7 +367,7 @@ func assertConfiguration(ctx context.Context, config *Configuration) error {
 
 // modifyFilePaths modifies a collection of filepaths in a *Configuration
 // file to make them relative to the configuration file (this makes it a lot easier
-// to store all config-related files in the same directory and to run the rosetta-cli
+// to store all config-related files in the same directory and to run the mesh-cli
 // from a different directory).
 func modifyFilePaths(config *Configuration, fileDir string) {
 	if config.Data != nil {

--- a/configuration/types.go
+++ b/configuration/types.go
@@ -129,7 +129,7 @@ type ConstructionConfiguration struct {
 	// to use while testing.
 	PrefundedAccounts []*modules.PrefundedAccount `json:"prefunded_accounts,omitempty"`
 
-	// Workflows are executed by the rosetta-cli to test
+	// Workflows are executed by the mesh-cli to test
 	// certain construction flows.
 	Workflows []*job.Workflow `json:"workflows"`
 
@@ -160,7 +160,7 @@ type ConstructionConfiguration struct {
 	// logging should be silenced.
 	Quiet bool `json:"quiet,omitempty"`
 
-	// InitialBalanceFetchDisabled configures rosetta-cli
+	// InitialBalanceFetchDisabled configures mesh-cli
 	// not to lookup the balance of newly seen accounts at the
 	// parent block before applying operations. Disabling this
 	// is only a good idea if you create multiple new accounts each block
@@ -281,7 +281,7 @@ type DataConfiguration struct {
 	// some of the more advanced checks to confirm syncing is working as expected.
 	ReconciliationDisabled bool `json:"reconciliation_disabled"`
 
-	// ReconciliationDrainDisabled is a boolean that configures the rosetta-cli
+	// ReconciliationDrainDisabled is a boolean that configures the mesh-cli
 	// to exit check:data before the entire active reconciliation queue has
 	// been drained (if reconciliation is enabled).
 	ReconciliationDrainDisabled bool `json:"reconciliation_drain_disabled"`
@@ -336,7 +336,7 @@ type DataConfiguration struct {
 	// provided in the `statefulsyncer` package.
 	PruningFrequency *int `json:"pruning_frequency,omitempty"`
 
-	// InitialBalanceFetchDisabled configures rosetta-cli
+	// InitialBalanceFetchDisabled configures mesh-cli
 	// not to lookup the balance of newly seen accounts at the
 	// parent block before applying operations. Disabling
 	// this step can significantly speed up performance
@@ -366,7 +366,7 @@ type Configuration struct {
 	TargetAccount string `json:"target_account,omitempty"`
 
 	// DataDirectory is a folder used to store logs and any data used to perform validation.
-	// The path can be absolute, or it can be relative to where rosetta-cli
+	// The path can be absolute, or it can be relative to where mesh-cli
 	// binary is being executed.
 	DataDirectory string `json:"data_directory"`
 
@@ -464,7 +464,7 @@ type Configuration struct {
 	// then this value must be true.
 	CoinSupported bool `json:"coin_supported"`
 
-	// InfoMetaData is a string, rosetta-cli will convert it into a map[string]string
+	// InfoMetaData is a string, mesh-cli will convert it into a map[string]string
 	// key-value are separated by ":"
 	// different key-value pairs are separated by ","
 	// an example: if users want to record "instance_name" as "1234", and "blockchain_name" as "Bitcoin",

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/coinbase/rosetta-cli
+module github.com/coinbase/mesh-cli
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"os"
 
-	"github.com/coinbase/rosetta-cli/cmd"
+	"github.com/coinbase/mesh-cli/cmd"
 
 	"github.com/fatih/color"
 )

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/coinbase/rosetta-cli/pkg/results"
+	"github.com/coinbase/mesh-cli/pkg/results"
 
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/reconciler"

--- a/pkg/processor/balance_storage_handler.go
+++ b/pkg/processor/balance_storage_handler.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/coinbase/rosetta-cli/pkg/logger"
+	"github.com/coinbase/mesh-cli/pkg/logger"
 
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/reconciler"

--- a/pkg/processor/broadcast_storage_handler.go
+++ b/pkg/processor/broadcast_storage_handler.go
@@ -20,7 +20,7 @@ import (
 	"math/big"
 	"reflect"
 
-	"github.com/coinbase/rosetta-cli/configuration"
+	"github.com/coinbase/mesh-cli/configuration"
 
 	"github.com/coinbase/rosetta-sdk-go/constructor/coordinator"
 	"github.com/coinbase/rosetta-sdk-go/parser"

--- a/pkg/processor/coordinator_helper.go
+++ b/pkg/processor/coordinator_helper.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"math/big"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 	"github.com/coinbase/rosetta-sdk-go/constructor/coordinator"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/keys"

--- a/pkg/processor/reconciler_handler.go
+++ b/pkg/processor/reconciler_handler.go
@@ -21,9 +21,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coinbase/rosetta-cli/pkg/logger"
+	"github.com/coinbase/mesh-cli/pkg/logger"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 	"github.com/coinbase/rosetta-sdk-go/reconciler"
 	"github.com/coinbase/rosetta-sdk-go/storage/modules"
 	"github.com/coinbase/rosetta-sdk-go/types"

--- a/pkg/processor/reconciler_helper.go
+++ b/pkg/processor/reconciler_helper.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/coinbase/rosetta-cli/configuration"
+	"github.com/coinbase/mesh-cli/configuration"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/reconciler"

--- a/pkg/results/construction_results.go
+++ b/pkg/results/construction_results.go
@@ -23,7 +23,7 @@ import (
 
 	pkgError "github.com/pkg/errors"
 
-	"github.com/coinbase/rosetta-cli/configuration"
+	"github.com/coinbase/mesh-cli/configuration"
 
 	"github.com/coinbase/rosetta-sdk-go/storage/modules"
 	"github.com/coinbase/rosetta-sdk-go/types"

--- a/pkg/results/data_results.go
+++ b/pkg/results/data_results.go
@@ -25,9 +25,9 @@ import (
 
 	pkgError "github.com/pkg/errors"
 
-	"github.com/coinbase/rosetta-cli/configuration"
+	"github.com/coinbase/mesh-cli/configuration"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/reconciler"

--- a/pkg/results/data_results_test.go
+++ b/pkg/results/data_results_test.go
@@ -22,9 +22,9 @@ import (
 	"path"
 	"testing"
 
-	"github.com/coinbase/rosetta-cli/configuration"
+	"github.com/coinbase/mesh-cli/configuration"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	sdkMocks "github.com/coinbase/rosetta-sdk-go/mocks/storage/modules"

--- a/pkg/results/perf_results.go
+++ b/pkg/results/perf_results.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/coinbase/rosetta-cli/configuration"
+	"github.com/coinbase/mesh-cli/configuration"
 	"github.com/coinbase/rosetta-sdk-go/utils"
 	"github.com/olekukonko/tablewriter"
 )

--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -323,7 +323,7 @@ func InitializeConstruction(
 	if err != nil {
 		msg := fmt.Sprintf("unable to create coordinator: %s%s", err.Error(), constructionMetadata)
 		color.Red(msg)
-		log.Fatalf(msg)
+		log.Fatal(msg)
 	}
 
 	broadcastHandler := processor.NewBroadcastStorageHandler(
@@ -375,7 +375,7 @@ func (t *ConstructionTester) CloseDatabase(ctx context.Context) {
 	if err := t.database.Close(ctx); err != nil {
 		msg := fmt.Sprintf("error closing database: %s%s", err.Error(), constructionMetadata)
 		color.Red(msg)
-		log.Fatalf(msg)
+		log.Fatal(msg)
 	}
 }
 

--- a/pkg/tester/construction.go
+++ b/pkg/tester/construction.go
@@ -23,12 +23,12 @@ import (
 	"net/http"
 	"time"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 
-	"github.com/coinbase/rosetta-cli/configuration"
-	"github.com/coinbase/rosetta-cli/pkg/logger"
-	"github.com/coinbase/rosetta-cli/pkg/processor"
-	"github.com/coinbase/rosetta-cli/pkg/results"
+	"github.com/coinbase/mesh-cli/configuration"
+	"github.com/coinbase/mesh-cli/pkg/logger"
+	"github.com/coinbase/mesh-cli/pkg/processor"
+	"github.com/coinbase/mesh-cli/pkg/results"
 
 	"github.com/coinbase/rosetta-sdk-go/constructor/coordinator"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -178,7 +178,7 @@ func (t *DataTester) CloseDatabase(ctx context.Context) {
 	if err := t.database.Close(ctx); err != nil {
 		msg := fmt.Sprintf("error closing database: %s%s", err.Error(), metadata)
 		color.Red(msg)
-		log.Fatalf(msg)
+		log.Fatal(msg)
 	}
 }
 
@@ -330,7 +330,7 @@ func InitializeData(
 	if fetchErr != nil {
 		msg := fmt.Sprintf("unable to get network options: %s%s", fetchErr.Err.Error(), metadata)
 		color.Red(msg)
-		log.Fatalf(msg)
+		log.Fatal(msg)
 	}
 
 	if len(networkOptions.Allow.BalanceExemptions) > 0 && config.Data.InitialBalanceFetchDisabled {

--- a/pkg/tester/data.go
+++ b/pkg/tester/data.go
@@ -24,12 +24,12 @@ import (
 	"net/http"
 	"time"
 
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
 
-	"github.com/coinbase/rosetta-cli/configuration"
-	"github.com/coinbase/rosetta-cli/pkg/logger"
-	"github.com/coinbase/rosetta-cli/pkg/processor"
-	"github.com/coinbase/rosetta-cli/pkg/results"
+	"github.com/coinbase/mesh-cli/configuration"
+	"github.com/coinbase/mesh-cli/pkg/logger"
+	"github.com/coinbase/mesh-cli/pkg/processor"
+	"github.com/coinbase/mesh-cli/pkg/results"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/reconciler"
@@ -414,7 +414,7 @@ func InitializeData(
 
 		// Bootstrap balances, if provided. We need to do before initializing
 		// the reconciler otherwise we won't reconcile bootstrapped accounts
-		// until rosetta-cli restart.
+		// until mesh-cli restart.
 		//
 		// We need to do this after instantiating the balance storage handler
 		// because it is invoked within BootstrapBalances.

--- a/pkg/tester/data_perf.go
+++ b/pkg/tester/data_perf.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/coinbase/rosetta-cli/configuration"
-	cliErrs "github.com/coinbase/rosetta-cli/pkg/errors"
-	"github.com/coinbase/rosetta-cli/pkg/results"
+	"github.com/coinbase/mesh-cli/configuration"
+	cliErrs "github.com/coinbase/mesh-cli/pkg/errors"
+	"github.com/coinbase/mesh-cli/pkg/results"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"
 )

--- a/pkg/tester/general.go
+++ b/pkg/tester/general.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/coinbase/rosetta-cli/pkg/logger"
+	"github.com/coinbase/mesh-cli/pkg/logger"
 )
 
 const (

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -23,9 +23,16 @@ LINUX_TARGETS="linux/amd64,linux/arm64,linux/mips64,linux/mips64le,linux/ppc64le
 WINDOWS_TARGET="windows/amd64"
 TARGETS="${MAC_TARGETS},${LINUX_TARGETS},${WINDOWS_TARGET}"
 
-xgo -go 1.16.3 --targets=${TARGETS} -out "bin/rosetta-cli-${VERSION}" .;
+# Build mesh-cli binaries
+# Just compile twice in case it's still referred to by its old name.
+xgo -go 1.24.8 --targets=${TARGETS} -out "bin/mesh-cli-${VERSION}" .;
+xgo -go 1.24.8 --targets=${TARGETS} -out "bin/rosetta-cli-${VERSION}" .;
 
-# Rename some files
+# Rename xgo output files to standard naming
+mv "bin/mesh-cli-${VERSION}-darwin-10.16-amd64" "bin/mesh-cli-${VERSION}-darwin-amd64"
+mv "bin/mesh-cli-${VERSION}-darwin-10.16-arm64" "bin/mesh-cli-${VERSION}-darwin-arm64"
+mv "bin/mesh-cli-${VERSION}-windows-4.0-amd64.exe" "bin/mesh-cli-${VERSION}-windows-amd64"
+
 mv "bin/rosetta-cli-${VERSION}-darwin-10.16-amd64" "bin/rosetta-cli-${VERSION}-darwin-amd64"
 mv "bin/rosetta-cli-${VERSION}-darwin-10.16-arm64" "bin/rosetta-cli-${VERSION}-darwin-arm64"
 mv "bin/rosetta-cli-${VERSION}-windows-4.0-amd64.exe" "bin/rosetta-cli-${VERSION}-windows-amd64"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,13 +20,13 @@ set -e
 usage() {
   this=$1
   cat <<EOF
-$this: download go binaries for coinbase/rosetta-cli
+$this: download go binaries for coinbase/mesh-cli
 
 Usage: $this [-b] bindir [-d] [tag]
   -b sets bindir or installation directory, Defaults to ./bin
   -d turns on debug logging
    [tag] is a tag from
-   https://github.com/coinbase/rosetta-cli/releases
+   https://github.com/coinbase/mesh-cli/releases
    If tag is missing, then the latest will be used.
 
 EOF
@@ -62,19 +62,22 @@ execute() {
   mv "${tmpdir}/${NAME}" "${tmpdir}/${BINARY}"
   install "${tmpdir}/${BINARY}" "${BINDIR}/"
   log_info "installed ${BINDIR}/${BINARY}"
+  # Create rosetta-cli symlink for backward compatibility
+  (cd "${BINDIR}" && ln -sf "${BINARY}" "rosetta-cli")
+  log_info "created symlink ${BINDIR}/rosetta-cli -> ${BINARY}"
   rm -rf "${tmpdir}"
 }
 get_binaries() {
   case "$PLATFORM" in
-    darwin/amd64) BINARY="rosetta-cli" ;;
-    darwin/arm64) BINARY="rosetta-cli" ;;
-    linux/amd64) BINARY="rosetta-cli" ;;
-    linux/arm64) BINARY="rosetta-cli" ;;
-    linux/mips64) BINARY="rosetta-cli" ;;
-    linux/mips64le) BINARY="rosetta-cli" ;;
-    linux/ppc64le) BINARY="rosetta-cli" ;;
-    linux/s390x) BINARY="rosetta-cli" ;;
-    windows/amd64) BINARY="rosetta-cli.exe" ;;
+    darwin/amd64) BINARY="mesh-cli" ;;
+    darwin/arm64) BINARY="mesh-cli" ;;
+    linux/amd64) BINARY="mesh-cli" ;;
+    linux/arm64) BINARY="mesh-cli" ;;
+    linux/mips64) BINARY="mesh-cli" ;;
+    linux/mips64le) BINARY="mesh-cli" ;;
+    linux/ppc64le) BINARY="mesh-cli" ;;
+    linux/s390x) BINARY="mesh-cli" ;;
+    windows/amd64) BINARY="mesh-cli.exe" ;;
     *)
       log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
       exit 1
@@ -297,10 +300,10 @@ End of functions from https://github.com/client9/shlib
 ------------------------------------------------------------------------
 EOF
 
-BINARY=rosetta-cli
+BINARY=mesh-cli
 FORMAT=tar.gz
 OWNER=coinbase
-REPO="rosetta-cli"
+REPO="mesh-cli"
 OS=$(uname_os)
 ARCH=$(uname_arch)
 PREFIX="$OWNER/$REPO"


### PR DESCRIPTION
* Renames to `mesh-cli`
* In an attempt to not break anything that still might want it to exist and be called rosetta-cli, I keep the 'rosetta-cli' binaries downloadable, and also have the install.sh script do a symlink to rosetta-cli from mesh-cli.
