### PR TITLE
Fix broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,9 @@ You can also view releases and change log information in the [Releases](https://
 
 ## Documentation
 
-You can find the Mesh API documentation [here](https://docs.cdp.coinbase.com/mesh/docs/welcome/)
+You can find the Mesh API documentation in the [`mesh-specifications`](https://github.com/coinbase/mesh-specifications) repository.
 
-For more information on the mesh-cli tool, read our [The mesh-cli tool](https://docs.cdp.coinbase.com/mesh/docs/mesh-cli/) documentation.
-
-For more information on how to test your implementation file with the `mesh-cli` tool, read our [How to Test Your Mesh Implementation](https://docs.cdp.coinbase.com/mesh/docs/mesh-test/) documentation.
+For more information on how to use and test your implementation with the `mesh-cli` tool, see the [examples](https://github.com/coinbase/mesh-cli/tree/master/examples) directory.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- All three documentation links in the README pointing to `docs.cdp.coinbase.com/mesh/docs/*` return 404 — the entire Mesh section has been removed from the Coinbase Developer Platform
- Replace with links to the [`mesh-specifications`](https://github.com/coinbase/mesh-specifications) GitHub repository (the authoritative OpenAPI 3.0 spec) and the [`examples`](https://github.com/coinbase/mesh-cli/tree/master/examples) directory in this repo

Fixes #431